### PR TITLE
Pin video intelligence samples to v1.

### DIFF
--- a/samples/analyze.js
+++ b/samples/analyze.js
@@ -18,7 +18,7 @@
 function analyzeFaces(gcsUri) {
   // [START analyze_faces]
   // Imports the Google Cloud Video Intelligence library
-  const video = require('@google-cloud/video-intelligence');
+  const video = require('@google-cloud/video-intelligence').v1;
 
   // Creates a client
   const client = new video.VideoIntelligenceServiceClient();
@@ -83,7 +83,7 @@ function analyzeFaces(gcsUri) {
 function analyzeLabelsGCS(gcsUri) {
   // [START analyze_labels_gcs]
   // Imports the Google Cloud Video Intelligence library
-  const video = require('@google-cloud/video-intelligence');
+  const video = require('@google-cloud/video-intelligence').v1;
 
   // Creates a client
   const client = new video.VideoIntelligenceServiceClient();
@@ -148,7 +148,7 @@ function analyzeLabelsGCS(gcsUri) {
 function analyzeLabelsLocal(path) {
   // [START analyze_labels_local]
   // Imports the Google Cloud Video Intelligence library + Node's fs library
-  const video = require('@google-cloud/video-intelligence');
+  const video = require('@google-cloud/video-intelligence').v1;
   const fs = require('fs');
 
   // Creates a client
@@ -219,7 +219,7 @@ function analyzeLabelsLocal(path) {
 function analyzeShots(gcsUri) {
   // [START analyze_shots]
   // Imports the Google Cloud Video Intelligence library
-  const video = require('@google-cloud/video-intelligence');
+  const video = require('@google-cloud/video-intelligence').v1;
 
   // Creates a client
   const client = new video.VideoIntelligenceServiceClient();
@@ -290,7 +290,7 @@ function analyzeShots(gcsUri) {
 function analyzeSafeSearch(gcsUri) {
   // [START analyze_safe_search]
   // Imports the Google Cloud Video Intelligence library
-  const video = require('@google-cloud/video-intelligence');
+  const video = require('@google-cloud/video-intelligence').v1;
 
   // Creates a client
   const client = new video.VideoIntelligenceServiceClient();


### PR DESCRIPTION
This updates the `v1beta2` samples to use `v1`. As the underlying API is equivalent, the samples work as-is.

NOTE: Considering `v1` is the new default, this change is entirely optional, depending on whether you want to expose the `.v1` in the samples or not. No updates are necessary otherwise; the samples (like user code) will continue to work as-is.