### PR TITLE
feat: generated GAPIC code for v1p1beta1

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "lint": "repo-tools lint --cmd eslint -- src/ samples/ test/",
     "prettier": "repo-tools exec -- prettier --write src/*.js src/*/*.js samples/*.js samples/*/*.js test/*.js test/*/*.js",
     "samples-test": "cd samples/ && npm link ../ && npm test && cd ../",
+    "system-test": "repo-tools test run --cmd mocha -- system-test/*.js --no-timeouts",
     "test-no-cover": "repo-tools test run --cmd mocha -- test/*.js --no-timeouts",
     "test": "repo-tools test run --cmd npm -- run cover"
   },

--- a/protos/google/cloud/videointelligence/v1p1beta1/video_intelligence.proto
+++ b/protos/google/cloud/videointelligence/v1p1beta1/video_intelligence.proto
@@ -1,0 +1,556 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.cloud.videointelligence.v1p1beta1;
+
+import "google/api/annotations.proto";
+import "google/longrunning/operations.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
+import "google/rpc/status.proto";
+
+option csharp_namespace = "Google.Cloud.VideoIntelligence.V1P1Beta1";
+option go_package = "google.golang.org/genproto/googleapis/cloud/videointelligence/v1p1beta1;videointelligence";
+option java_multiple_files = true;
+option java_outer_classname = "VideoIntelligenceServiceProto";
+option java_package = "com.google.cloud.videointelligence.v1p1beta1";
+option php_namespace = "Google\\Cloud\\VideoIntelligence\\V1p1beta1";
+
+
+// Service that implements Google Cloud Video Intelligence API.
+service VideoIntelligenceService {
+  // Performs asynchronous video annotation. Progress and results can be
+  // retrieved through the `google.longrunning.Operations` interface.
+  // `Operation.metadata` contains `AnnotateVideoProgress` (progress).
+  // `Operation.response` contains `AnnotateVideoResponse` (results).
+  rpc AnnotateVideo(AnnotateVideoRequest) returns (google.longrunning.Operation) {
+    option (google.api.http) = {
+      post: "/v1p1beta1/videos:annotate"
+      body: "*"
+    };
+  }
+}
+
+// Video annotation request.
+message AnnotateVideoRequest {
+  // Input video location. Currently, only
+  // [Google Cloud Storage](https://cloud.google.com/storage/) URIs are
+  // supported, which must be specified in the following format:
+  // `gs://bucket-id/object-id` (other URI formats return
+  // [google.rpc.Code.INVALID_ARGUMENT][google.rpc.Code.INVALID_ARGUMENT]). For more information, see
+  // [Request URIs](/storage/docs/reference-uris).
+  // A video URI may include wildcards in `object-id`, and thus identify
+  // multiple videos. Supported wildcards: '*' to match 0 or more characters;
+  // '?' to match 1 character. If unset, the input video should be embedded
+  // in the request as `input_content`. If set, `input_content` should be unset.
+  string input_uri = 1;
+
+  // The video data bytes.
+  // If unset, the input video(s) should be specified via `input_uri`.
+  // If set, `input_uri` should be unset.
+  bytes input_content = 6;
+
+  // Requested video annotation features.
+  repeated Feature features = 2;
+
+  // Additional video context and/or feature-specific parameters.
+  VideoContext video_context = 3;
+
+  // Optional location where the output (in JSON format) should be stored.
+  // Currently, only [Google Cloud Storage](https://cloud.google.com/storage/)
+  // URIs are supported, which must be specified in the following format:
+  // `gs://bucket-id/object-id` (other URI formats return
+  // [google.rpc.Code.INVALID_ARGUMENT][google.rpc.Code.INVALID_ARGUMENT]). For more information, see
+  // [Request URIs](/storage/docs/reference-uris).
+  string output_uri = 4;
+
+  // Optional cloud region where annotation should take place. Supported cloud
+  // regions: `us-east1`, `us-west1`, `europe-west1`, `asia-east1`. If no region
+  // is specified, a region will be determined based on video file location.
+  string location_id = 5;
+}
+
+// Video context and/or feature-specific parameters.
+message VideoContext {
+  // Video segments to annotate. The segments may overlap and are not required
+  // to be contiguous or span the whole video. If unspecified, each video
+  // is treated as a single segment.
+  repeated VideoSegment segments = 1;
+
+  // Config for LABEL_DETECTION.
+  LabelDetectionConfig label_detection_config = 2;
+
+  // Config for SHOT_CHANGE_DETECTION.
+  ShotChangeDetectionConfig shot_change_detection_config = 3;
+
+  // Config for EXPLICIT_CONTENT_DETECTION.
+  ExplicitContentDetectionConfig explicit_content_detection_config = 4;
+
+  // Config for SPEECH_TRANSCRIPTION.
+  SpeechTranscriptionConfig speech_transcription_config = 6;
+
+  // Config for FACE_DETECTION.
+  FaceConfig face_detection_config = 7;
+}
+
+// Config for LABEL_DETECTION.
+message LabelDetectionConfig {
+  // What labels should be detected with LABEL_DETECTION, in addition to
+  // video-level labels or segment-level labels.
+  // If unspecified, defaults to `SHOT_MODE`.
+  LabelDetectionMode label_detection_mode = 1;
+
+  // Whether the video has been shot from a stationary (i.e. non-moving) camera.
+  // When set to true, might improve detection accuracy for moving objects.
+  // Should be used with `SHOT_AND_FRAME_MODE` enabled.
+  bool stationary_camera = 2;
+
+  // Model to use for label detection.
+  // Supported values: "builtin/stable" (the default if unset) and
+  // "builtin/latest".
+  string model = 3;
+}
+
+// Config for SHOT_CHANGE_DETECTION.
+message ShotChangeDetectionConfig {
+  // Model to use for shot change detection.
+  // Supported values: "builtin/stable" (the default if unset) and
+  // "builtin/latest".
+  string model = 1;
+}
+
+// Config for EXPLICIT_CONTENT_DETECTION.
+message ExplicitContentDetectionConfig {
+  // Model to use for explicit content detection.
+  // Supported values: "builtin/stable" (the default if unset) and
+  // "builtin/latest".
+  string model = 1;
+}
+
+// Config for FACE_DETECTION.
+message FaceConfig {
+  // Model to use for face detection.
+  // Supported values: "builtin/stable" (the default if unset) and
+  // "builtin/latest".
+  string model = 1;
+
+  // Whether bounding boxes be included in the face annotation output.
+  bool include_bounding_boxes = 2;
+
+  // Whether to enable emotion detection. Ignored if 'include_bounding_boxes' is
+  // false.
+  bool include_emotions = 4;
+}
+
+// Video segment.
+message VideoSegment {
+  // Time-offset, relative to the beginning of the video,
+  // corresponding to the start of the segment (inclusive).
+  google.protobuf.Duration start_time_offset = 1;
+
+  // Time-offset, relative to the beginning of the video,
+  // corresponding to the end of the segment (inclusive).
+  google.protobuf.Duration end_time_offset = 2;
+}
+
+// Video segment level annotation results for label detection.
+message LabelSegment {
+  // Video segment where a label was detected.
+  VideoSegment segment = 1;
+
+  // Confidence that the label is accurate. Range: [0, 1].
+  float confidence = 2;
+}
+
+// Video frame level annotation results for label detection.
+message LabelFrame {
+  // Time-offset, relative to the beginning of the video, corresponding to the
+  // video frame for this location.
+  google.protobuf.Duration time_offset = 1;
+
+  // Confidence that the label is accurate. Range: [0, 1].
+  float confidence = 2;
+}
+
+// Detected entity from video analysis.
+message Entity {
+  // Opaque entity ID. Some IDs may be available in
+  // [Google Knowledge Graph Search
+  // API](https://developers.google.com/knowledge-graph/).
+  string entity_id = 1;
+
+  // Textual description, e.g. `Fixed-gear bicycle`.
+  string description = 2;
+
+  // Language code for `description` in BCP-47 format.
+  string language_code = 3;
+}
+
+// Label annotation.
+message LabelAnnotation {
+  // Detected entity.
+  Entity entity = 1;
+
+  // Common categories for the detected entity.
+  // E.g. when the label is `Terrier` the category is likely `dog`. And in some
+  // cases there might be more than one categories e.g. `Terrier` could also be
+  // a `pet`.
+  repeated Entity category_entities = 2;
+
+  // All video segments where a label was detected.
+  repeated LabelSegment segments = 3;
+
+  // All video frames where a label was detected.
+  repeated LabelFrame frames = 4;
+}
+
+// Video frame level annotation results for explicit content.
+message ExplicitContentFrame {
+  // Time-offset, relative to the beginning of the video, corresponding to the
+  // video frame for this location.
+  google.protobuf.Duration time_offset = 1;
+
+  // Likelihood of the pornography content..
+  Likelihood pornography_likelihood = 2;
+}
+
+// Explicit content annotation (based on per-frame visual signals only).
+// If no explicit content has been detected in a frame, no annotations are
+// present for that frame.
+message ExplicitContentAnnotation {
+  // All video frames where explicit content was detected.
+  repeated ExplicitContentFrame frames = 1;
+}
+
+// Normalized bounding box.
+// The normalized vertex coordinates are relative to the original image.
+// Range: [0, 1].
+message NormalizedBoundingBox {
+  // Left X coordinate.
+  float left = 1;
+
+  // Top Y coordinate.
+  float top = 2;
+
+  // Right X coordinate.
+  float right = 3;
+
+  // Bottom Y coordinate.
+  float bottom = 4;
+}
+
+// Video segment level annotation results for face detection.
+message FaceSegment {
+  // Video segment where a face was detected.
+  VideoSegment segment = 1;
+}
+
+// Video frame level annotation results for face detection.
+message FaceDetectionFrame {
+  // Face attributes in a frame.
+  // There can be more than one attributes if the same face is detected in
+  // multiple locations within the current frame.
+  repeated FaceDetectionAttribute attributes = 1;
+
+  // Time-offset, relative to the beginning of the video,
+  // corresponding to the video frame for this location.
+  google.protobuf.Duration time_offset = 2;
+}
+
+// Face detection attribute.
+message FaceDetectionAttribute {
+  // Normalized Bounding box.
+  NormalizedBoundingBox normalized_bounding_box = 1;
+
+  // Emotion attributes.
+  repeated EmotionAttribute emotions = 2;
+}
+
+// Emotion attribute.
+message EmotionAttribute {
+  // Emotion entry.
+  Emotion emotion = 1;
+
+  // Confidence score.
+  float score = 2;
+}
+
+// Face detection annotation.
+message FaceDetectionAnnotation {
+  // All video segments where a face was detected.
+  repeated FaceSegment segments = 1;
+
+  // All video frames where a face was detected.
+  repeated FaceDetectionFrame frames = 2;
+}
+
+// Annotation results for a single video.
+message VideoAnnotationResults {
+  // Video file location in
+  // [Google Cloud Storage](https://cloud.google.com/storage/).
+  string input_uri = 1;
+
+  // Label annotations on video level or user specified segment level.
+  // There is exactly one element for each unique label.
+  repeated LabelAnnotation segment_label_annotations = 2;
+
+  // Label annotations on shot level.
+  // There is exactly one element for each unique label.
+  repeated LabelAnnotation shot_label_annotations = 3;
+
+  // Label annotations on frame level.
+  // There is exactly one element for each unique label.
+  repeated LabelAnnotation frame_label_annotations = 4;
+
+  // Face detection annotations.
+  repeated FaceDetectionAnnotation face_detection_annotations = 13;
+
+  // Shot annotations. Each shot is represented as a video segment.
+  repeated VideoSegment shot_annotations = 6;
+
+  // Explicit content annotation.
+  ExplicitContentAnnotation explicit_annotation = 7;
+
+  // Speech transcription.
+  repeated SpeechTranscription speech_transcriptions = 11;
+
+  // If set, indicates an error. Note that for a single `AnnotateVideoRequest`
+  // some videos may succeed and some may fail.
+  google.rpc.Status error = 9;
+}
+
+// Video annotation response. Included in the `response`
+// field of the `Operation` returned by the `GetOperation`
+// call of the `google::longrunning::Operations` service.
+message AnnotateVideoResponse {
+  // Annotation results for all videos specified in `AnnotateVideoRequest`.
+  repeated VideoAnnotationResults annotation_results = 1;
+}
+
+// Annotation progress for a single video.
+message VideoAnnotationProgress {
+  // Video file location in
+  // [Google Cloud Storage](https://cloud.google.com/storage/).
+  string input_uri = 1;
+
+  // Approximate percentage processed thus far.
+  // Guaranteed to be 100 when fully processed.
+  int32 progress_percent = 2;
+
+  // Time when the request was received.
+  google.protobuf.Timestamp start_time = 3;
+
+  // Time of the most recent update.
+  google.protobuf.Timestamp update_time = 4;
+}
+
+// Video annotation progress. Included in the `metadata`
+// field of the `Operation` returned by the `GetOperation`
+// call of the `google::longrunning::Operations` service.
+message AnnotateVideoProgress {
+  // Progress metadata for all videos specified in `AnnotateVideoRequest`.
+  repeated VideoAnnotationProgress annotation_progress = 1;
+}
+
+// Config for SPEECH_TRANSCRIPTION.
+message SpeechTranscriptionConfig {
+  // *Required* The language of the supplied audio as a
+  // [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag.
+  // Example: "en-US".
+  // See [Language Support](https://cloud.google.com/speech/docs/languages)
+  // for a list of the currently supported language codes.
+  string language_code = 1;
+
+  // *Optional* Maximum number of recognition hypotheses to be returned.
+  // Specifically, the maximum number of `SpeechRecognitionAlternative` messages
+  // within each `SpeechRecognitionResult`. The server may return fewer than
+  // `max_alternatives`. Valid values are `0`-`30`. A value of `0` or `1` will
+  // return a maximum of one. If omitted, will return a maximum of one.
+  int32 max_alternatives = 2;
+
+  // *Optional* If set to `true`, the server will attempt to filter out
+  // profanities, replacing all but the initial character in each filtered word
+  // with asterisks, e.g. "f***". If set to `false` or omitted, profanities
+  // won't be filtered out.
+  bool filter_profanity = 3;
+
+  // *Optional* A means to provide context to assist the speech recognition.
+  repeated SpeechContext speech_contexts = 4;
+
+  // *Optional* For file formats, such as MXF or MKV, supporting multiple audio
+  // tracks, specify up to two tracks. Default: track 0.
+  repeated int32 audio_tracks = 6;
+}
+
+// Provides "hints" to the speech recognizer to favor specific words and phrases
+// in the results.
+message SpeechContext {
+  // *Optional* A list of strings containing words and phrases "hints" so that
+  // the speech recognition is more likely to recognize them. This can be used
+  // to improve the accuracy for specific words and phrases, for example, if
+  // specific commands are typically spoken by the user. This can also be used
+  // to add additional words to the vocabulary of the recognizer. See
+  // [usage limits](https://cloud.google.com/speech/limits#content).
+  repeated string phrases = 1;
+}
+
+// A speech recognition result corresponding to a portion of the audio.
+message SpeechTranscription {
+  // Output only. May contain one or more recognition hypotheses (up to the
+  // maximum specified in `max_alternatives`).
+  // These alternatives are ordered in terms of accuracy, with the top (first)
+  // alternative being the most probable, as ranked by the recognizer.
+  repeated SpeechRecognitionAlternative alternatives = 1;
+}
+
+// Alternative hypotheses (a.k.a. n-best list).
+message SpeechRecognitionAlternative {
+  // Output only. Transcript text representing the words that the user spoke.
+  string transcript = 1;
+
+  // Output only. The confidence estimate between 0.0 and 1.0. A higher number
+  // indicates an estimated greater likelihood that the recognized words are
+  // correct. This field is typically provided only for the top hypothesis, and
+  // only for `is_final=true` results. Clients should not rely on the
+  // `confidence` field as it is not guaranteed to be accurate or consistent.
+  // The default of 0.0 is a sentinel value indicating `confidence` was not set.
+  float confidence = 2;
+
+  // Output only. A list of word-specific information for each recognized word.
+  repeated WordInfo words = 3;
+}
+
+// Word-specific information for recognized words. Word information is only
+// included in the response when certain request parameters are set, such
+// as `enable_word_time_offsets`.
+message WordInfo {
+  // Output only. Time offset relative to the beginning of the audio, and
+  // corresponding to the start of the spoken word. This field is only set if
+  // `enable_word_time_offsets=true` and only in the top hypothesis. This is an
+  // experimental feature and the accuracy of the time offset can vary.
+  google.protobuf.Duration start_time = 1;
+
+  // Output only. Time offset relative to the beginning of the audio, and
+  // corresponding to the end of the spoken word. This field is only set if
+  // `enable_word_time_offsets=true` and only in the top hypothesis. This is an
+  // experimental feature and the accuracy of the time offset can vary.
+  google.protobuf.Duration end_time = 2;
+
+  // Output only. The word corresponding to this set of information.
+  string word = 3;
+}
+
+// Video annotation feature.
+enum Feature {
+  // Unspecified.
+  FEATURE_UNSPECIFIED = 0;
+
+  // Label detection. Detect objects, such as dog or flower.
+  LABEL_DETECTION = 1;
+
+  // Shot change detection.
+  SHOT_CHANGE_DETECTION = 2;
+
+  // Explicit content detection.
+  EXPLICIT_CONTENT_DETECTION = 3;
+
+  // Face detection.
+  FACE_DETECTION = 8;
+
+  // Speech transcription.
+  SPEECH_TRANSCRIPTION = 6;
+}
+
+// Label detection mode.
+enum LabelDetectionMode {
+  // Unspecified.
+  LABEL_DETECTION_MODE_UNSPECIFIED = 0;
+
+  // Detect shot-level labels.
+  SHOT_MODE = 1;
+
+  // Detect frame-level labels.
+  FRAME_MODE = 2;
+
+  // Detect both shot-level and frame-level labels.
+  SHOT_AND_FRAME_MODE = 3;
+}
+
+// Bucketized representation of likelihood.
+enum Likelihood {
+  // Unspecified likelihood.
+  LIKELIHOOD_UNSPECIFIED = 0;
+
+  // Very unlikely.
+  VERY_UNLIKELY = 1;
+
+  // Unlikely.
+  UNLIKELY = 2;
+
+  // Possible.
+  POSSIBLE = 3;
+
+  // Likely.
+  LIKELY = 4;
+
+  // Very likely.
+  VERY_LIKELY = 5;
+}
+
+// Emotions.
+enum Emotion {
+  // Unspecified emotion.
+  EMOTION_UNSPECIFIED = 0;
+
+  // Amusement.
+  AMUSEMENT = 1;
+
+  // Anger.
+  ANGER = 2;
+
+  // Concentration.
+  CONCENTRATION = 3;
+
+  // Contentment.
+  CONTENTMENT = 4;
+
+  // Desire.
+  DESIRE = 5;
+
+  // Disappointment.
+  DISAPPOINTMENT = 6;
+
+  // Disgust.
+  DISGUST = 7;
+
+  // Elation.
+  ELATION = 8;
+
+  // Embarrassment.
+  EMBARRASSMENT = 9;
+
+  // Interest.
+  INTEREST = 10;
+
+  // Pride.
+  PRIDE = 11;
+
+  // Sadness.
+  SADNESS = 12;
+
+  // Surprise.
+  SURPRISE = 13;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,7 @@ const gapic = Object.freeze({
   v1: require('./v1'),
   v1beta2: require('./v1beta2'),
   v1beta1: require('./v1beta1'),
+  v1p1beta1: require('./v1p1beta1'),
 });
 
 /**
@@ -120,6 +121,13 @@ module.exports.v1beta2 = gapic.v1beta2;
  *   Reference to {@link v1beta1.VideoIntelligenceServiceClient}
  */
 module.exports.v1beta1 = gapic.v1beta1;
+
+/**
+ * @type {object}
+ * @property {constructor} VideoIntelligenceServiceClient
+ *   Reference to {@link v1p1beta1.VideoIntelligenceServiceClient}
+ */
+module.exports.v1p1beta1 = gapic.v1p1beta1;
 
 // Alias `module.exports` as `module.exports.default`, for future-proofing.
 module.exports.default = Object.assign({}, module.exports);

--- a/src/v1p1beta1/doc/google/cloud/videointelligence/v1p1beta1/doc_video_intelligence.js
+++ b/src/v1p1beta1/doc/google/cloud/videointelligence/v1p1beta1/doc_video_intelligence.js
@@ -1,0 +1,925 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
+
+/**
+ * Video annotation request.
+ *
+ * @property {string} inputUri
+ *   Input video location. Currently, only
+ *   [Google Cloud Storage](https://cloud.google.com/storage/) URIs are
+ *   supported, which must be specified in the following format:
+ *   `gs://bucket-id/object-id` (other URI formats return
+ *   google.rpc.Code.INVALID_ARGUMENT). For more information, see
+ *   [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
+ *   A video URI may include wildcards in `object-id`, and thus identify
+ *   multiple videos. Supported wildcards: '*' to match 0 or more characters;
+ *   '?' to match 1 character. If unset, the input video should be embedded
+ *   in the request as `input_content`. If set, `input_content` should be unset.
+ *
+ * @property {string} inputContent
+ *   The video data bytes.
+ *   If unset, the input video(s) should be specified via `input_uri`.
+ *   If set, `input_uri` should be unset.
+ *
+ * @property {number[]} features
+ *   Requested video annotation features.
+ *
+ *   The number should be among the values of [Feature]{@link google.cloud.videointelligence.v1p1beta1.Feature}
+ *
+ * @property {Object} videoContext
+ *   Additional video context and/or feature-specific parameters.
+ *
+ *   This object should have the same structure as [VideoContext]{@link google.cloud.videointelligence.v1p1beta1.VideoContext}
+ *
+ * @property {string} outputUri
+ *   Optional location where the output (in JSON format) should be stored.
+ *   Currently, only [Google Cloud Storage](https://cloud.google.com/storage/)
+ *   URIs are supported, which must be specified in the following format:
+ *   `gs://bucket-id/object-id` (other URI formats return
+ *   google.rpc.Code.INVALID_ARGUMENT). For more information, see
+ *   [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
+ *
+ * @property {string} locationId
+ *   Optional cloud region where annotation should take place. Supported cloud
+ *   regions: `us-east1`, `us-west1`, `europe-west1`, `asia-east1`. If no region
+ *   is specified, a region will be determined based on video file location.
+ *
+ * @typedef AnnotateVideoRequest
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ * @see [google.cloud.videointelligence.v1p1beta1.AnnotateVideoRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/videointelligence/v1p1beta1/video_intelligence.proto}
+ */
+var AnnotateVideoRequest = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Video context and/or feature-specific parameters.
+ *
+ * @property {Object[]} segments
+ *   Video segments to annotate. The segments may overlap and are not required
+ *   to be contiguous or span the whole video. If unspecified, each video
+ *   is treated as a single segment.
+ *
+ *   This object should have the same structure as [VideoSegment]{@link google.cloud.videointelligence.v1p1beta1.VideoSegment}
+ *
+ * @property {Object} labelDetectionConfig
+ *   Config for LABEL_DETECTION.
+ *
+ *   This object should have the same structure as [LabelDetectionConfig]{@link google.cloud.videointelligence.v1p1beta1.LabelDetectionConfig}
+ *
+ * @property {Object} shotChangeDetectionConfig
+ *   Config for SHOT_CHANGE_DETECTION.
+ *
+ *   This object should have the same structure as [ShotChangeDetectionConfig]{@link google.cloud.videointelligence.v1p1beta1.ShotChangeDetectionConfig}
+ *
+ * @property {Object} explicitContentDetectionConfig
+ *   Config for EXPLICIT_CONTENT_DETECTION.
+ *
+ *   This object should have the same structure as [ExplicitContentDetectionConfig]{@link google.cloud.videointelligence.v1p1beta1.ExplicitContentDetectionConfig}
+ *
+ * @property {Object} speechTranscriptionConfig
+ *   Config for SPEECH_TRANSCRIPTION.
+ *
+ *   This object should have the same structure as [SpeechTranscriptionConfig]{@link google.cloud.videointelligence.v1p1beta1.SpeechTranscriptionConfig}
+ *
+ * @property {Object} faceDetectionConfig
+ *   Config for FACE_DETECTION.
+ *
+ *   This object should have the same structure as [FaceConfig]{@link google.cloud.videointelligence.v1p1beta1.FaceConfig}
+ *
+ * @typedef VideoContext
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ * @see [google.cloud.videointelligence.v1p1beta1.VideoContext definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/videointelligence/v1p1beta1/video_intelligence.proto}
+ */
+var VideoContext = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Config for LABEL_DETECTION.
+ *
+ * @property {number} labelDetectionMode
+ *   What labels should be detected with LABEL_DETECTION, in addition to
+ *   video-level labels or segment-level labels.
+ *   If unspecified, defaults to `SHOT_MODE`.
+ *
+ *   The number should be among the values of [LabelDetectionMode]{@link google.cloud.videointelligence.v1p1beta1.LabelDetectionMode}
+ *
+ * @property {boolean} stationaryCamera
+ *   Whether the video has been shot from a stationary (i.e. non-moving) camera.
+ *   When set to true, might improve detection accuracy for moving objects.
+ *   Should be used with `SHOT_AND_FRAME_MODE` enabled.
+ *
+ * @property {string} model
+ *   Model to use for label detection.
+ *   Supported values: "builtin/stable" (the default if unset) and
+ *   "builtin/latest".
+ *
+ * @typedef LabelDetectionConfig
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ * @see [google.cloud.videointelligence.v1p1beta1.LabelDetectionConfig definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/videointelligence/v1p1beta1/video_intelligence.proto}
+ */
+var LabelDetectionConfig = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Config for SHOT_CHANGE_DETECTION.
+ *
+ * @property {string} model
+ *   Model to use for shot change detection.
+ *   Supported values: "builtin/stable" (the default if unset) and
+ *   "builtin/latest".
+ *
+ * @typedef ShotChangeDetectionConfig
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ * @see [google.cloud.videointelligence.v1p1beta1.ShotChangeDetectionConfig definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/videointelligence/v1p1beta1/video_intelligence.proto}
+ */
+var ShotChangeDetectionConfig = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Config for EXPLICIT_CONTENT_DETECTION.
+ *
+ * @property {string} model
+ *   Model to use for explicit content detection.
+ *   Supported values: "builtin/stable" (the default if unset) and
+ *   "builtin/latest".
+ *
+ * @typedef ExplicitContentDetectionConfig
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ * @see [google.cloud.videointelligence.v1p1beta1.ExplicitContentDetectionConfig definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/videointelligence/v1p1beta1/video_intelligence.proto}
+ */
+var ExplicitContentDetectionConfig = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Config for FACE_DETECTION.
+ *
+ * @property {string} model
+ *   Model to use for face detection.
+ *   Supported values: "builtin/stable" (the default if unset) and
+ *   "builtin/latest".
+ *
+ * @property {boolean} includeBoundingBoxes
+ *   Whether bounding boxes be included in the face annotation output.
+ *
+ * @property {boolean} includeEmotions
+ *   Whether to enable emotion detection. Ignored if 'include_bounding_boxes' is
+ *   false.
+ *
+ * @typedef FaceConfig
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ * @see [google.cloud.videointelligence.v1p1beta1.FaceConfig definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/videointelligence/v1p1beta1/video_intelligence.proto}
+ */
+var FaceConfig = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Video segment.
+ *
+ * @property {Object} startTimeOffset
+ *   Time-offset, relative to the beginning of the video,
+ *   corresponding to the start of the segment (inclusive).
+ *
+ *   This object should have the same structure as [Duration]{@link google.protobuf.Duration}
+ *
+ * @property {Object} endTimeOffset
+ *   Time-offset, relative to the beginning of the video,
+ *   corresponding to the end of the segment (inclusive).
+ *
+ *   This object should have the same structure as [Duration]{@link google.protobuf.Duration}
+ *
+ * @typedef VideoSegment
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ * @see [google.cloud.videointelligence.v1p1beta1.VideoSegment definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/videointelligence/v1p1beta1/video_intelligence.proto}
+ */
+var VideoSegment = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Video segment level annotation results for label detection.
+ *
+ * @property {Object} segment
+ *   Video segment where a label was detected.
+ *
+ *   This object should have the same structure as [VideoSegment]{@link google.cloud.videointelligence.v1p1beta1.VideoSegment}
+ *
+ * @property {number} confidence
+ *   Confidence that the label is accurate. Range: [0, 1].
+ *
+ * @typedef LabelSegment
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ * @see [google.cloud.videointelligence.v1p1beta1.LabelSegment definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/videointelligence/v1p1beta1/video_intelligence.proto}
+ */
+var LabelSegment = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Video frame level annotation results for label detection.
+ *
+ * @property {Object} timeOffset
+ *   Time-offset, relative to the beginning of the video, corresponding to the
+ *   video frame for this location.
+ *
+ *   This object should have the same structure as [Duration]{@link google.protobuf.Duration}
+ *
+ * @property {number} confidence
+ *   Confidence that the label is accurate. Range: [0, 1].
+ *
+ * @typedef LabelFrame
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ * @see [google.cloud.videointelligence.v1p1beta1.LabelFrame definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/videointelligence/v1p1beta1/video_intelligence.proto}
+ */
+var LabelFrame = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Detected entity from video analysis.
+ *
+ * @property {string} entityId
+ *   Opaque entity ID. Some IDs may be available in
+ *   [Google Knowledge Graph Search
+ *   API](https://developers.google.com/knowledge-graph/).
+ *
+ * @property {string} description
+ *   Textual description, e.g. `Fixed-gear bicycle`.
+ *
+ * @property {string} languageCode
+ *   Language code for `description` in BCP-47 format.
+ *
+ * @typedef Entity
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ * @see [google.cloud.videointelligence.v1p1beta1.Entity definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/videointelligence/v1p1beta1/video_intelligence.proto}
+ */
+var Entity = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Label annotation.
+ *
+ * @property {Object} entity
+ *   Detected entity.
+ *
+ *   This object should have the same structure as [Entity]{@link google.cloud.videointelligence.v1p1beta1.Entity}
+ *
+ * @property {Object[]} categoryEntities
+ *   Common categories for the detected entity.
+ *   E.g. when the label is `Terrier` the category is likely `dog`. And in some
+ *   cases there might be more than one categories e.g. `Terrier` could also be
+ *   a `pet`.
+ *
+ *   This object should have the same structure as [Entity]{@link google.cloud.videointelligence.v1p1beta1.Entity}
+ *
+ * @property {Object[]} segments
+ *   All video segments where a label was detected.
+ *
+ *   This object should have the same structure as [LabelSegment]{@link google.cloud.videointelligence.v1p1beta1.LabelSegment}
+ *
+ * @property {Object[]} frames
+ *   All video frames where a label was detected.
+ *
+ *   This object should have the same structure as [LabelFrame]{@link google.cloud.videointelligence.v1p1beta1.LabelFrame}
+ *
+ * @typedef LabelAnnotation
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ * @see [google.cloud.videointelligence.v1p1beta1.LabelAnnotation definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/videointelligence/v1p1beta1/video_intelligence.proto}
+ */
+var LabelAnnotation = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Video frame level annotation results for explicit content.
+ *
+ * @property {Object} timeOffset
+ *   Time-offset, relative to the beginning of the video, corresponding to the
+ *   video frame for this location.
+ *
+ *   This object should have the same structure as [Duration]{@link google.protobuf.Duration}
+ *
+ * @property {number} pornographyLikelihood
+ *   Likelihood of the pornography content..
+ *
+ *   The number should be among the values of [Likelihood]{@link google.cloud.videointelligence.v1p1beta1.Likelihood}
+ *
+ * @typedef ExplicitContentFrame
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ * @see [google.cloud.videointelligence.v1p1beta1.ExplicitContentFrame definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/videointelligence/v1p1beta1/video_intelligence.proto}
+ */
+var ExplicitContentFrame = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Explicit content annotation (based on per-frame visual signals only).
+ * If no explicit content has been detected in a frame, no annotations are
+ * present for that frame.
+ *
+ * @property {Object[]} frames
+ *   All video frames where explicit content was detected.
+ *
+ *   This object should have the same structure as [ExplicitContentFrame]{@link google.cloud.videointelligence.v1p1beta1.ExplicitContentFrame}
+ *
+ * @typedef ExplicitContentAnnotation
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ * @see [google.cloud.videointelligence.v1p1beta1.ExplicitContentAnnotation definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/videointelligence/v1p1beta1/video_intelligence.proto}
+ */
+var ExplicitContentAnnotation = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Normalized bounding box.
+ * The normalized vertex coordinates are relative to the original image.
+ * Range: [0, 1].
+ *
+ * @property {number} left
+ *   Left X coordinate.
+ *
+ * @property {number} top
+ *   Top Y coordinate.
+ *
+ * @property {number} right
+ *   Right X coordinate.
+ *
+ * @property {number} bottom
+ *   Bottom Y coordinate.
+ *
+ * @typedef NormalizedBoundingBox
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ * @see [google.cloud.videointelligence.v1p1beta1.NormalizedBoundingBox definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/videointelligence/v1p1beta1/video_intelligence.proto}
+ */
+var NormalizedBoundingBox = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Video segment level annotation results for face detection.
+ *
+ * @property {Object} segment
+ *   Video segment where a face was detected.
+ *
+ *   This object should have the same structure as [VideoSegment]{@link google.cloud.videointelligence.v1p1beta1.VideoSegment}
+ *
+ * @typedef FaceSegment
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ * @see [google.cloud.videointelligence.v1p1beta1.FaceSegment definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/videointelligence/v1p1beta1/video_intelligence.proto}
+ */
+var FaceSegment = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Video frame level annotation results for face detection.
+ *
+ * @property {Object[]} attributes
+ *   Face attributes in a frame.
+ *   There can be more than one attributes if the same face is detected in
+ *   multiple locations within the current frame.
+ *
+ *   This object should have the same structure as [FaceDetectionAttribute]{@link google.cloud.videointelligence.v1p1beta1.FaceDetectionAttribute}
+ *
+ * @property {Object} timeOffset
+ *   Time-offset, relative to the beginning of the video,
+ *   corresponding to the video frame for this location.
+ *
+ *   This object should have the same structure as [Duration]{@link google.protobuf.Duration}
+ *
+ * @typedef FaceDetectionFrame
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ * @see [google.cloud.videointelligence.v1p1beta1.FaceDetectionFrame definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/videointelligence/v1p1beta1/video_intelligence.proto}
+ */
+var FaceDetectionFrame = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Face detection attribute.
+ *
+ * @property {Object} normalizedBoundingBox
+ *   Normalized Bounding box.
+ *
+ *   This object should have the same structure as [NormalizedBoundingBox]{@link google.cloud.videointelligence.v1p1beta1.NormalizedBoundingBox}
+ *
+ * @property {Object[]} emotions
+ *   Emotion attributes.
+ *
+ *   This object should have the same structure as [EmotionAttribute]{@link google.cloud.videointelligence.v1p1beta1.EmotionAttribute}
+ *
+ * @typedef FaceDetectionAttribute
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ * @see [google.cloud.videointelligence.v1p1beta1.FaceDetectionAttribute definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/videointelligence/v1p1beta1/video_intelligence.proto}
+ */
+var FaceDetectionAttribute = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Emotion attribute.
+ *
+ * @property {number} emotion
+ *   Emotion entry.
+ *
+ *   The number should be among the values of [Emotion]{@link google.cloud.videointelligence.v1p1beta1.Emotion}
+ *
+ * @property {number} score
+ *   Confidence score.
+ *
+ * @typedef EmotionAttribute
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ * @see [google.cloud.videointelligence.v1p1beta1.EmotionAttribute definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/videointelligence/v1p1beta1/video_intelligence.proto}
+ */
+var EmotionAttribute = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Face detection annotation.
+ *
+ * @property {Object[]} segments
+ *   All video segments where a face was detected.
+ *
+ *   This object should have the same structure as [FaceSegment]{@link google.cloud.videointelligence.v1p1beta1.FaceSegment}
+ *
+ * @property {Object[]} frames
+ *   All video frames where a face was detected.
+ *
+ *   This object should have the same structure as [FaceDetectionFrame]{@link google.cloud.videointelligence.v1p1beta1.FaceDetectionFrame}
+ *
+ * @typedef FaceDetectionAnnotation
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ * @see [google.cloud.videointelligence.v1p1beta1.FaceDetectionAnnotation definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/videointelligence/v1p1beta1/video_intelligence.proto}
+ */
+var FaceDetectionAnnotation = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Annotation results for a single video.
+ *
+ * @property {string} inputUri
+ *   Video file location in
+ *   [Google Cloud Storage](https://cloud.google.com/storage/).
+ *
+ * @property {Object[]} segmentLabelAnnotations
+ *   Label annotations on video level or user specified segment level.
+ *   There is exactly one element for each unique label.
+ *
+ *   This object should have the same structure as [LabelAnnotation]{@link google.cloud.videointelligence.v1p1beta1.LabelAnnotation}
+ *
+ * @property {Object[]} shotLabelAnnotations
+ *   Label annotations on shot level.
+ *   There is exactly one element for each unique label.
+ *
+ *   This object should have the same structure as [LabelAnnotation]{@link google.cloud.videointelligence.v1p1beta1.LabelAnnotation}
+ *
+ * @property {Object[]} frameLabelAnnotations
+ *   Label annotations on frame level.
+ *   There is exactly one element for each unique label.
+ *
+ *   This object should have the same structure as [LabelAnnotation]{@link google.cloud.videointelligence.v1p1beta1.LabelAnnotation}
+ *
+ * @property {Object[]} faceDetectionAnnotations
+ *   Face detection annotations.
+ *
+ *   This object should have the same structure as [FaceDetectionAnnotation]{@link google.cloud.videointelligence.v1p1beta1.FaceDetectionAnnotation}
+ *
+ * @property {Object[]} shotAnnotations
+ *   Shot annotations. Each shot is represented as a video segment.
+ *
+ *   This object should have the same structure as [VideoSegment]{@link google.cloud.videointelligence.v1p1beta1.VideoSegment}
+ *
+ * @property {Object} explicitAnnotation
+ *   Explicit content annotation.
+ *
+ *   This object should have the same structure as [ExplicitContentAnnotation]{@link google.cloud.videointelligence.v1p1beta1.ExplicitContentAnnotation}
+ *
+ * @property {Object[]} speechTranscriptions
+ *   Speech transcription.
+ *
+ *   This object should have the same structure as [SpeechTranscription]{@link google.cloud.videointelligence.v1p1beta1.SpeechTranscription}
+ *
+ * @property {Object} error
+ *   If set, indicates an error. Note that for a single `AnnotateVideoRequest`
+ *   some videos may succeed and some may fail.
+ *
+ *   This object should have the same structure as [Status]{@link google.rpc.Status}
+ *
+ * @typedef VideoAnnotationResults
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ * @see [google.cloud.videointelligence.v1p1beta1.VideoAnnotationResults definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/videointelligence/v1p1beta1/video_intelligence.proto}
+ */
+var VideoAnnotationResults = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Video annotation response. Included in the `response`
+ * field of the `Operation` returned by the `GetOperation`
+ * call of the `google::longrunning::Operations` service.
+ *
+ * @property {Object[]} annotationResults
+ *   Annotation results for all videos specified in `AnnotateVideoRequest`.
+ *
+ *   This object should have the same structure as [VideoAnnotationResults]{@link google.cloud.videointelligence.v1p1beta1.VideoAnnotationResults}
+ *
+ * @typedef AnnotateVideoResponse
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ * @see [google.cloud.videointelligence.v1p1beta1.AnnotateVideoResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/videointelligence/v1p1beta1/video_intelligence.proto}
+ */
+var AnnotateVideoResponse = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Annotation progress for a single video.
+ *
+ * @property {string} inputUri
+ *   Video file location in
+ *   [Google Cloud Storage](https://cloud.google.com/storage/).
+ *
+ * @property {number} progressPercent
+ *   Approximate percentage processed thus far.
+ *   Guaranteed to be 100 when fully processed.
+ *
+ * @property {Object} startTime
+ *   Time when the request was received.
+ *
+ *   This object should have the same structure as [Timestamp]{@link google.protobuf.Timestamp}
+ *
+ * @property {Object} updateTime
+ *   Time of the most recent update.
+ *
+ *   This object should have the same structure as [Timestamp]{@link google.protobuf.Timestamp}
+ *
+ * @typedef VideoAnnotationProgress
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ * @see [google.cloud.videointelligence.v1p1beta1.VideoAnnotationProgress definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/videointelligence/v1p1beta1/video_intelligence.proto}
+ */
+var VideoAnnotationProgress = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Video annotation progress. Included in the `metadata`
+ * field of the `Operation` returned by the `GetOperation`
+ * call of the `google::longrunning::Operations` service.
+ *
+ * @property {Object[]} annotationProgress
+ *   Progress metadata for all videos specified in `AnnotateVideoRequest`.
+ *
+ *   This object should have the same structure as [VideoAnnotationProgress]{@link google.cloud.videointelligence.v1p1beta1.VideoAnnotationProgress}
+ *
+ * @typedef AnnotateVideoProgress
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ * @see [google.cloud.videointelligence.v1p1beta1.AnnotateVideoProgress definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/videointelligence/v1p1beta1/video_intelligence.proto}
+ */
+var AnnotateVideoProgress = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Config for SPEECH_TRANSCRIPTION.
+ *
+ * @property {string} languageCode
+ *   *Required* The language of the supplied audio as a
+ *   [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag.
+ *   Example: "en-US".
+ *   See [Language Support](https://cloud.google.com/speech/docs/languages)
+ *   for a list of the currently supported language codes.
+ *
+ * @property {number} maxAlternatives
+ *   *Optional* Maximum number of recognition hypotheses to be returned.
+ *   Specifically, the maximum number of `SpeechRecognitionAlternative` messages
+ *   within each `SpeechRecognitionResult`. The server may return fewer than
+ *   `max_alternatives`. Valid values are `0`-`30`. A value of `0` or `1` will
+ *   return a maximum of one. If omitted, will return a maximum of one.
+ *
+ * @property {boolean} filterProfanity
+ *   *Optional* If set to `true`, the server will attempt to filter out
+ *   profanities, replacing all but the initial character in each filtered word
+ *   with asterisks, e.g. "f***". If set to `false` or omitted, profanities
+ *   won't be filtered out.
+ *
+ * @property {Object[]} speechContexts
+ *   *Optional* A means to provide context to assist the speech recognition.
+ *
+ *   This object should have the same structure as [SpeechContext]{@link google.cloud.videointelligence.v1p1beta1.SpeechContext}
+ *
+ * @property {number[]} audioTracks
+ *   *Optional* For file formats, such as MXF or MKV, supporting multiple audio
+ *   tracks, specify up to two tracks. Default: track 0.
+ *
+ * @typedef SpeechTranscriptionConfig
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ * @see [google.cloud.videointelligence.v1p1beta1.SpeechTranscriptionConfig definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/videointelligence/v1p1beta1/video_intelligence.proto}
+ */
+var SpeechTranscriptionConfig = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Provides "hints" to the speech recognizer to favor specific words and phrases
+ * in the results.
+ *
+ * @property {string[]} phrases
+ *   *Optional* A list of strings containing words and phrases "hints" so that
+ *   the speech recognition is more likely to recognize them. This can be used
+ *   to improve the accuracy for specific words and phrases, for example, if
+ *   specific commands are typically spoken by the user. This can also be used
+ *   to add additional words to the vocabulary of the recognizer. See
+ *   [usage limits](https://cloud.google.com/speech/limits#content).
+ *
+ * @typedef SpeechContext
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ * @see [google.cloud.videointelligence.v1p1beta1.SpeechContext definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/videointelligence/v1p1beta1/video_intelligence.proto}
+ */
+var SpeechContext = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * A speech recognition result corresponding to a portion of the audio.
+ *
+ * @property {Object[]} alternatives
+ *   Output only. May contain one or more recognition hypotheses (up to the
+ *   maximum specified in `max_alternatives`).
+ *   These alternatives are ordered in terms of accuracy, with the top (first)
+ *   alternative being the most probable, as ranked by the recognizer.
+ *
+ *   This object should have the same structure as [SpeechRecognitionAlternative]{@link google.cloud.videointelligence.v1p1beta1.SpeechRecognitionAlternative}
+ *
+ * @typedef SpeechTranscription
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ * @see [google.cloud.videointelligence.v1p1beta1.SpeechTranscription definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/videointelligence/v1p1beta1/video_intelligence.proto}
+ */
+var SpeechTranscription = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Alternative hypotheses (a.k.a. n-best list).
+ *
+ * @property {string} transcript
+ *   Output only. Transcript text representing the words that the user spoke.
+ *
+ * @property {number} confidence
+ *   Output only. The confidence estimate between 0.0 and 1.0. A higher number
+ *   indicates an estimated greater likelihood that the recognized words are
+ *   correct. This field is typically provided only for the top hypothesis, and
+ *   only for `is_final=true` results. Clients should not rely on the
+ *   `confidence` field as it is not guaranteed to be accurate or consistent.
+ *   The default of 0.0 is a sentinel value indicating `confidence` was not set.
+ *
+ * @property {Object[]} words
+ *   Output only. A list of word-specific information for each recognized word.
+ *
+ *   This object should have the same structure as [WordInfo]{@link google.cloud.videointelligence.v1p1beta1.WordInfo}
+ *
+ * @typedef SpeechRecognitionAlternative
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ * @see [google.cloud.videointelligence.v1p1beta1.SpeechRecognitionAlternative definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/videointelligence/v1p1beta1/video_intelligence.proto}
+ */
+var SpeechRecognitionAlternative = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Word-specific information for recognized words. Word information is only
+ * included in the response when certain request parameters are set, such
+ * as `enable_word_time_offsets`.
+ *
+ * @property {Object} startTime
+ *   Output only. Time offset relative to the beginning of the audio, and
+ *   corresponding to the start of the spoken word. This field is only set if
+ *   `enable_word_time_offsets=true` and only in the top hypothesis. This is an
+ *   experimental feature and the accuracy of the time offset can vary.
+ *
+ *   This object should have the same structure as [Duration]{@link google.protobuf.Duration}
+ *
+ * @property {Object} endTime
+ *   Output only. Time offset relative to the beginning of the audio, and
+ *   corresponding to the end of the spoken word. This field is only set if
+ *   `enable_word_time_offsets=true` and only in the top hypothesis. This is an
+ *   experimental feature and the accuracy of the time offset can vary.
+ *
+ *   This object should have the same structure as [Duration]{@link google.protobuf.Duration}
+ *
+ * @property {string} word
+ *   Output only. The word corresponding to this set of information.
+ *
+ * @typedef WordInfo
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ * @see [google.cloud.videointelligence.v1p1beta1.WordInfo definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/cloud/videointelligence/v1p1beta1/video_intelligence.proto}
+ */
+var WordInfo = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Video annotation feature.
+ *
+ * @enum {number}
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ */
+var Feature = {
+
+  /**
+   * Unspecified.
+   */
+  FEATURE_UNSPECIFIED: 0,
+
+  /**
+   * Label detection. Detect objects, such as dog or flower.
+   */
+  LABEL_DETECTION: 1,
+
+  /**
+   * Shot change detection.
+   */
+  SHOT_CHANGE_DETECTION: 2,
+
+  /**
+   * Explicit content detection.
+   */
+  EXPLICIT_CONTENT_DETECTION: 3,
+
+  /**
+   * Face detection.
+   */
+  FACE_DETECTION: 8,
+
+  /**
+   * Speech transcription.
+   */
+  SPEECH_TRANSCRIPTION: 6
+};
+
+/**
+ * Label detection mode.
+ *
+ * @enum {number}
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ */
+var LabelDetectionMode = {
+
+  /**
+   * Unspecified.
+   */
+  LABEL_DETECTION_MODE_UNSPECIFIED: 0,
+
+  /**
+   * Detect shot-level labels.
+   */
+  SHOT_MODE: 1,
+
+  /**
+   * Detect frame-level labels.
+   */
+  FRAME_MODE: 2,
+
+  /**
+   * Detect both shot-level and frame-level labels.
+   */
+  SHOT_AND_FRAME_MODE: 3
+};
+
+/**
+ * Bucketized representation of likelihood.
+ *
+ * @enum {number}
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ */
+var Likelihood = {
+
+  /**
+   * Unspecified likelihood.
+   */
+  LIKELIHOOD_UNSPECIFIED: 0,
+
+  /**
+   * Very unlikely.
+   */
+  VERY_UNLIKELY: 1,
+
+  /**
+   * Unlikely.
+   */
+  UNLIKELY: 2,
+
+  /**
+   * Possible.
+   */
+  POSSIBLE: 3,
+
+  /**
+   * Likely.
+   */
+  LIKELY: 4,
+
+  /**
+   * Very likely.
+   */
+  VERY_LIKELY: 5
+};
+
+/**
+ * Emotions.
+ *
+ * @enum {number}
+ * @memberof google.cloud.videointelligence.v1p1beta1
+ */
+var Emotion = {
+
+  /**
+   * Unspecified emotion.
+   */
+  EMOTION_UNSPECIFIED: 0,
+
+  /**
+   * Amusement.
+   */
+  AMUSEMENT: 1,
+
+  /**
+   * Anger.
+   */
+  ANGER: 2,
+
+  /**
+   * Concentration.
+   */
+  CONCENTRATION: 3,
+
+  /**
+   * Contentment.
+   */
+  CONTENTMENT: 4,
+
+  /**
+   * Desire.
+   */
+  DESIRE: 5,
+
+  /**
+   * Disappointment.
+   */
+  DISAPPOINTMENT: 6,
+
+  /**
+   * Disgust.
+   */
+  DISGUST: 7,
+
+  /**
+   * Elation.
+   */
+  ELATION: 8,
+
+  /**
+   * Embarrassment.
+   */
+  EMBARRASSMENT: 9,
+
+  /**
+   * Interest.
+   */
+  INTEREST: 10,
+
+  /**
+   * Pride.
+   */
+  PRIDE: 11,
+
+  /**
+   * Sadness.
+   */
+  SADNESS: 12,
+
+  /**
+   * Surprise.
+   */
+  SURPRISE: 13
+};

--- a/src/v1p1beta1/doc/google/protobuf/doc_any.js
+++ b/src/v1p1beta1/doc/google/protobuf/doc_any.js
@@ -1,0 +1,131 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
+
+/**
+ * `Any` contains an arbitrary serialized protocol buffer message along with a
+ * URL that describes the type of the serialized message.
+ *
+ * Protobuf library provides support to pack/unpack Any values in the form
+ * of utility functions or additional generated methods of the Any type.
+ *
+ * Example 1: Pack and unpack a message in C++.
+ *
+ *     Foo foo = ...;
+ *     Any any;
+ *     any.PackFrom(foo);
+ *     ...
+ *     if (any.UnpackTo(&foo)) {
+ *       ...
+ *     }
+ *
+ * Example 2: Pack and unpack a message in Java.
+ *
+ *     Foo foo = ...;
+ *     Any any = Any.pack(foo);
+ *     ...
+ *     if (any.is(Foo.class)) {
+ *       foo = any.unpack(Foo.class);
+ *     }
+ *
+ *  Example 3: Pack and unpack a message in Python.
+ *
+ *     foo = Foo(...)
+ *     any = Any()
+ *     any.Pack(foo)
+ *     ...
+ *     if any.Is(Foo.DESCRIPTOR):
+ *       any.Unpack(foo)
+ *       ...
+ *
+ *  Example 4: Pack and unpack a message in Go
+ *
+ *      foo := &pb.Foo{...}
+ *      any, err := ptypes.MarshalAny(foo)
+ *      ...
+ *      foo := &pb.Foo{}
+ *      if err := ptypes.UnmarshalAny(any, foo); err != nil {
+ *        ...
+ *      }
+ *
+ * The pack methods provided by protobuf library will by default use
+ * 'type.googleapis.com/full.type.name' as the type URL and the unpack
+ * methods only use the fully qualified type name after the last '/'
+ * in the type URL, for example "foo.bar.com/x/y.z" will yield type
+ * name "y.z".
+ *
+ *
+ * # JSON
+ *
+ * The JSON representation of an `Any` value uses the regular
+ * representation of the deserialized, embedded message, with an
+ * additional field `@type` which contains the type URL. Example:
+ *
+ *     package google.profile;
+ *     message Person {
+ *       string first_name = 1;
+ *       string last_name = 2;
+ *     }
+ *
+ *     {
+ *       "@type": "type.googleapis.com/google.profile.Person",
+ *       "firstName": <string>,
+ *       "lastName": <string>
+ *     }
+ *
+ * If the embedded message type is well-known and has a custom JSON
+ * representation, that representation will be embedded adding a field
+ * `value` which holds the custom JSON in addition to the `@type`
+ * field. Example (for message google.protobuf.Duration):
+ *
+ *     {
+ *       "@type": "type.googleapis.com/google.protobuf.Duration",
+ *       "value": "1.212s"
+ *     }
+ *
+ * @property {string} typeUrl
+ *   A URL/resource name whose content describes the type of the
+ *   serialized protocol buffer message.
+ *
+ *   For URLs which use the scheme `http`, `https`, or no scheme, the
+ *   following restrictions and interpretations apply:
+ *
+ *   * If no scheme is provided, `https` is assumed.
+ *   * The last segment of the URL's path must represent the fully
+ *     qualified name of the type (as in `path/google.protobuf.Duration`).
+ *     The name should be in a canonical form (e.g., leading "." is
+ *     not accepted).
+ *   * An HTTP GET on the URL must yield a google.protobuf.Type
+ *     value in binary format, or produce an error.
+ *   * Applications are allowed to cache lookup results based on the
+ *     URL, or have them precompiled into a binary to avoid any
+ *     lookup. Therefore, binary compatibility needs to be preserved
+ *     on changes to types. (Use versioned type names to manage
+ *     breaking changes.)
+ *
+ *   Schemes other than `http`, `https` (or the empty scheme) might be
+ *   used with implementation specific semantics.
+ *
+ * @property {string} value
+ *   Must be a valid serialized protocol buffer of the above specified type.
+ *
+ * @typedef Any
+ * @memberof google.protobuf
+ * @see [google.protobuf.Any definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/any.proto}
+ */
+var Any = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};

--- a/src/v1p1beta1/doc/google/protobuf/doc_duration.js
+++ b/src/v1p1beta1/doc/google/protobuf/doc_duration.js
@@ -1,0 +1,97 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
+
+/**
+ * A Duration represents a signed, fixed-length span of time represented
+ * as a count of seconds and fractions of seconds at nanosecond
+ * resolution. It is independent of any calendar and concepts like "day"
+ * or "month". It is related to Timestamp in that the difference between
+ * two Timestamp values is a Duration and it can be added or subtracted
+ * from a Timestamp. Range is approximately +-10,000 years.
+ *
+ * # Examples
+ *
+ * Example 1: Compute Duration from two Timestamps in pseudo code.
+ *
+ *     Timestamp start = ...;
+ *     Timestamp end = ...;
+ *     Duration duration = ...;
+ *
+ *     duration.seconds = end.seconds - start.seconds;
+ *     duration.nanos = end.nanos - start.nanos;
+ *
+ *     if (duration.seconds < 0 && duration.nanos > 0) {
+ *       duration.seconds += 1;
+ *       duration.nanos -= 1000000000;
+ *     } else if (durations.seconds > 0 && duration.nanos < 0) {
+ *       duration.seconds -= 1;
+ *       duration.nanos += 1000000000;
+ *     }
+ *
+ * Example 2: Compute Timestamp from Timestamp + Duration in pseudo code.
+ *
+ *     Timestamp start = ...;
+ *     Duration duration = ...;
+ *     Timestamp end = ...;
+ *
+ *     end.seconds = start.seconds + duration.seconds;
+ *     end.nanos = start.nanos + duration.nanos;
+ *
+ *     if (end.nanos < 0) {
+ *       end.seconds -= 1;
+ *       end.nanos += 1000000000;
+ *     } else if (end.nanos >= 1000000000) {
+ *       end.seconds += 1;
+ *       end.nanos -= 1000000000;
+ *     }
+ *
+ * Example 3: Compute Duration from datetime.timedelta in Python.
+ *
+ *     td = datetime.timedelta(days=3, minutes=10)
+ *     duration = Duration()
+ *     duration.FromTimedelta(td)
+ *
+ * # JSON Mapping
+ *
+ * In JSON format, the Duration type is encoded as a string rather than an
+ * object, where the string ends in the suffix "s" (indicating seconds) and
+ * is preceded by the number of seconds, with nanoseconds expressed as
+ * fractional seconds. For example, 3 seconds with 0 nanoseconds should be
+ * encoded in JSON format as "3s", while 3 seconds and 1 nanosecond should
+ * be expressed in JSON format as "3.000000001s", and 3 seconds and 1
+ * microsecond should be expressed in JSON format as "3.000001s".
+ *
+ * @property {number} seconds
+ *   Signed seconds of the span of time. Must be from -315,576,000,000
+ *   to +315,576,000,000 inclusive. Note: these bounds are computed from:
+ *   60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+ *
+ * @property {number} nanos
+ *   Signed fractions of a second at nanosecond resolution of the span
+ *   of time. Durations less than one second are represented with a 0
+ *   `seconds` field and a positive or negative `nanos` field. For durations
+ *   of one second or more, a non-zero value for the `nanos` field must be
+ *   of the same sign as the `seconds` field. Must be from -999,999,999
+ *   to +999,999,999 inclusive.
+ *
+ * @typedef Duration
+ * @memberof google.protobuf
+ * @see [google.protobuf.Duration definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/duration.proto}
+ */
+var Duration = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};

--- a/src/v1p1beta1/doc/google/rpc/doc_status.js
+++ b/src/v1p1beta1/doc/google/rpc/doc_status.js
@@ -1,0 +1,92 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
+
+/**
+ * The `Status` type defines a logical error model that is suitable for different
+ * programming environments, including REST APIs and RPC APIs. It is used by
+ * [gRPC](https://github.com/grpc). The error model is designed to be:
+ *
+ * - Simple to use and understand for most users
+ * - Flexible enough to meet unexpected needs
+ *
+ * # Overview
+ *
+ * The `Status` message contains three pieces of data: error code, error message,
+ * and error details. The error code should be an enum value of
+ * google.rpc.Code, but it may accept additional error codes if needed.  The
+ * error message should be a developer-facing English message that helps
+ * developers *understand* and *resolve* the error. If a localized user-facing
+ * error message is needed, put the localized message in the error details or
+ * localize it in the client. The optional error details may contain arbitrary
+ * information about the error. There is a predefined set of error detail types
+ * in the package `google.rpc` that can be used for common error conditions.
+ *
+ * # Language mapping
+ *
+ * The `Status` message is the logical representation of the error model, but it
+ * is not necessarily the actual wire format. When the `Status` message is
+ * exposed in different client libraries and different wire protocols, it can be
+ * mapped differently. For example, it will likely be mapped to some exceptions
+ * in Java, but more likely mapped to some error codes in C.
+ *
+ * # Other uses
+ *
+ * The error model and the `Status` message can be used in a variety of
+ * environments, either with or without APIs, to provide a
+ * consistent developer experience across different environments.
+ *
+ * Example uses of this error model include:
+ *
+ * - Partial errors. If a service needs to return partial errors to the client,
+ *     it may embed the `Status` in the normal response to indicate the partial
+ *     errors.
+ *
+ * - Workflow errors. A typical workflow has multiple steps. Each step may
+ *     have a `Status` message for error reporting.
+ *
+ * - Batch operations. If a client uses batch request and batch response, the
+ *     `Status` message should be used directly inside batch response, one for
+ *     each error sub-response.
+ *
+ * - Asynchronous operations. If an API call embeds asynchronous operation
+ *     results in its response, the status of those operations should be
+ *     represented directly using the `Status` message.
+ *
+ * - Logging. If some API errors are stored in logs, the message `Status` could
+ *     be used directly after any stripping needed for security/privacy reasons.
+ *
+ * @property {number} code
+ *   The status code, which should be an enum value of google.rpc.Code.
+ *
+ * @property {string} message
+ *   A developer-facing error message, which should be in English. Any
+ *   user-facing error message should be localized and sent in the
+ *   google.rpc.Status.details field, or localized by the client.
+ *
+ * @property {Object[]} details
+ *   A list of messages that carry the error details.  There is a common set of
+ *   message types for APIs to use.
+ *
+ *   This object should have the same structure as [Any]{@link google.protobuf.Any}
+ *
+ * @typedef Status
+ * @memberof google.rpc
+ * @see [google.rpc.Status definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto}
+ */
+var Status = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};

--- a/src/v1p1beta1/index.js
+++ b/src/v1p1beta1/index.js
@@ -1,0 +1,19 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const VideoIntelligenceServiceClient = require('./video_intelligence_service_client');
+
+module.exports.VideoIntelligenceServiceClient = VideoIntelligenceServiceClient;

--- a/src/v1p1beta1/video_intelligence_service_client.js
+++ b/src/v1p1beta1/video_intelligence_service_client.js
@@ -1,0 +1,345 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const gapicConfig = require('./video_intelligence_service_client_config');
+const gax = require('google-gax');
+const merge = require('lodash.merge');
+const path = require('path');
+const protobuf = require('protobufjs');
+
+const VERSION = require('../../package.json').version;
+
+/**
+ * Service that implements Google Cloud Video Intelligence API.
+ *
+ * @class
+ * @memberof v1p1beta1
+ */
+class VideoIntelligenceServiceClient {
+  /**
+   * Construct an instance of VideoIntelligenceServiceClient.
+   *
+   * @param {object} [options] - The configuration object. See the subsequent
+   *   parameters for more details.
+   * @param {object} [options.credentials] - Credentials object.
+   * @param {string} [options.credentials.client_email]
+   * @param {string} [options.credentials.private_key]
+   * @param {string} [options.email] - Account email address. Required when
+   *     using a .pem or .p12 keyFilename.
+   * @param {string} [options.keyFilename] - Full path to the a .json, .pem, or
+   *     .p12 key downloaded from the Google Developers Console. If you provide
+   *     a path to a JSON file, the projectId option below is not necessary.
+   *     NOTE: .pem and .p12 require you to specify options.email as well.
+   * @param {number} [options.port] - The port on which to connect to
+   *     the remote host.
+   * @param {string} [options.projectId] - The project ID from the Google
+   *     Developer's Console, e.g. 'grape-spaceship-123'. We will also check
+   *     the environment variable GCLOUD_PROJECT for your project ID. If your
+   *     app is running in an environment which supports
+   *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
+   *     your project ID will be detected automatically.
+   * @param {function} [options.promise] - Custom promise module to use instead
+   *     of native Promises.
+   * @param {string} [options.servicePath] - The domain name of the
+   *     API remote host.
+   */
+  constructor(opts) {
+    this._descriptors = {};
+
+    // Ensure that options include the service address and port.
+    opts = Object.assign(
+      {
+        clientConfig: {},
+        port: this.constructor.port,
+        servicePath: this.constructor.servicePath,
+      },
+      opts
+    );
+
+    // Create a `gaxGrpc` object, with any grpc-specific options
+    // sent to the client.
+    opts.scopes = this.constructor.scopes;
+    var gaxGrpc = gax.grpc(opts);
+
+    // Save the auth object to the client, for use by other methods.
+    this.auth = gaxGrpc.auth;
+
+    // Determine the client header string.
+    var clientHeader = [
+      `gl-node/${process.version.node}`,
+      `grpc/${gaxGrpc.grpcVersion}`,
+      `gax/${gax.version}`,
+      `gapic/${VERSION}`,
+    ];
+    if (opts.libName && opts.libVersion) {
+      clientHeader.push(`${opts.libName}/${opts.libVersion}`);
+    }
+
+    // Load the applicable protos.
+    var protos = merge(
+      {},
+      gaxGrpc.loadProto(
+        path.join(__dirname, '..', '..', 'protos'),
+        'google/cloud/videointelligence/v1p1beta1/video_intelligence.proto'
+      )
+    );
+    var protoFilesRoot = new gax.grpc.GoogleProtoFilesRoot();
+    protoFilesRoot = protobuf.loadSync(
+      path.join(
+        __dirname,
+        '..',
+        '..',
+        'protos',
+        'google/cloud/videointelligence/v1p1beta1/video_intelligence.proto'
+      ),
+      protoFilesRoot
+    );
+
+    // This API contains "long-running operations", which return a
+    // an Operation object that allows for tracking of the operation,
+    // rather than holding a request open.
+    this.operationsClient = new gax.lro({
+      auth: gaxGrpc.auth,
+      grpc: gaxGrpc.grpc,
+    }).operationsClient(opts);
+
+    var annotateVideoResponse = protoFilesRoot.lookup(
+      'google.cloud.videointelligence.v1p1beta1.AnnotateVideoResponse'
+    );
+    var annotateVideoMetadata = protoFilesRoot.lookup(
+      'google.cloud.videointelligence.v1p1beta1.AnnotateVideoProgress'
+    );
+
+    this._descriptors.longrunning = {
+      annotateVideo: new gax.LongrunningDescriptor(
+        this.operationsClient,
+        annotateVideoResponse.decode.bind(annotateVideoResponse),
+        annotateVideoMetadata.decode.bind(annotateVideoMetadata)
+      ),
+    };
+
+    // Put together the default options sent with requests.
+    var defaults = gaxGrpc.constructSettings(
+      'google.cloud.videointelligence.v1p1beta1.VideoIntelligenceService',
+      gapicConfig,
+      opts.clientConfig,
+      {'x-goog-api-client': clientHeader.join(' ')}
+    );
+
+    // Set up a dictionary of "inner API calls"; the core implementation
+    // of calling the API is handled in `google-gax`, with this code
+    // merely providing the destination and request information.
+    this._innerApiCalls = {};
+
+    // Put together the "service stub" for
+    // google.cloud.videointelligence.v1p1beta1.VideoIntelligenceService.
+    var videoIntelligenceServiceStub = gaxGrpc.createStub(
+      protos.google.cloud.videointelligence.v1p1beta1.VideoIntelligenceService,
+      opts
+    );
+
+    // Iterate over each of the methods that the service provides
+    // and create an API call method for each.
+    var videoIntelligenceServiceStubMethods = ['annotateVideo'];
+    for (let methodName of videoIntelligenceServiceStubMethods) {
+      this._innerApiCalls[methodName] = gax.createApiCall(
+        videoIntelligenceServiceStub.then(
+          stub =>
+            function() {
+              var args = Array.prototype.slice.call(arguments, 0);
+              return stub[methodName].apply(stub, args);
+            }
+        ),
+        defaults[methodName],
+        this._descriptors.longrunning[methodName]
+      );
+    }
+  }
+
+  /**
+   * The DNS address for this API service.
+   */
+  static get servicePath() {
+    return 'videointelligence.googleapis.com';
+  }
+
+  /**
+   * The port for this API service.
+   */
+  static get port() {
+    return 443;
+  }
+
+  /**
+   * The scopes needed to make gRPC calls for every method defined
+   * in this service.
+   */
+  static get scopes() {
+    return ['https://www.googleapis.com/auth/cloud-platform'];
+  }
+
+  /**
+   * Return the project ID used by this class.
+   * @param {function(Error, string)} callback - the callback to
+   *   be called with the current project Id.
+   */
+  getProjectId(callback) {
+    return this.auth.getProjectId(callback);
+  }
+
+  // -------------------
+  // -- Service calls --
+  // -------------------
+
+  /**
+   * Performs asynchronous video annotation. Progress and results can be
+   * retrieved through the `google.longrunning.Operations` interface.
+   * `Operation.metadata` contains `AnnotateVideoProgress` (progress).
+   * `Operation.response` contains `AnnotateVideoResponse` (results).
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} [request.inputUri]
+   *   Input video location. Currently, only
+   *   [Google Cloud Storage](https://cloud.google.com/storage/) URIs are
+   *   supported, which must be specified in the following format:
+   *   `gs://bucket-id/object-id` (other URI formats return
+   *   google.rpc.Code.INVALID_ARGUMENT). For more information, see
+   *   [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
+   *   A video URI may include wildcards in `object-id`, and thus identify
+   *   multiple videos. Supported wildcards: '*' to match 0 or more characters;
+   *   '?' to match 1 character. If unset, the input video should be embedded
+   *   in the request as `input_content`. If set, `input_content` should be unset.
+   * @param {string} [request.inputContent]
+   *   The video data bytes.
+   *   If unset, the input video(s) should be specified via `input_uri`.
+   *   If set, `input_uri` should be unset.
+   * @param {number[]} [request.features]
+   *   Requested video annotation features.
+   *
+   *   The number should be among the values of [Feature]{@link google.cloud.videointelligence.v1p1beta1.Feature}
+   * @param {Object} [request.videoContext]
+   *   Additional video context and/or feature-specific parameters.
+   *
+   *   This object should have the same structure as [VideoContext]{@link google.cloud.videointelligence.v1p1beta1.VideoContext}
+   * @param {string} [request.outputUri]
+   *   Optional location where the output (in JSON format) should be stored.
+   *   Currently, only [Google Cloud Storage](https://cloud.google.com/storage/)
+   *   URIs are supported, which must be specified in the following format:
+   *   `gs://bucket-id/object-id` (other URI formats return
+   *   google.rpc.Code.INVALID_ARGUMENT). For more information, see
+   *   [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
+   * @param {string} [request.locationId]
+   *   Optional cloud region where annotation should take place. Supported cloud
+   *   regions: `us-east1`, `us-west1`, `europe-west1`, `asia-east1`. If no region
+   *   is specified, a region will be determined based on video file location.
+   * @param {Object} [options]
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)} [callback]
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/Operation} object.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/Operation} object.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * const videoIntelligence = require('@google-cloud/video-intelligence');
+   *
+   * var client = new videoIntelligence.v1p1beta1.VideoIntelligenceServiceClient({
+   *   // optional auth parameters.
+   * });
+   *
+   * var inputUri = 'gs://demomaker/cat.mp4';
+   * var featuresElement = 'LABEL_DETECTION';
+   * var features = [featuresElement];
+   * var request = {
+   *   inputUri: inputUri,
+   *   features: features,
+   * };
+   *
+   * // Handle the operation using the promise pattern.
+   * client.annotateVideo(request)
+   *   .then(responses => {
+   *     var operation = responses[0];
+   *     var initialApiResponse = responses[1];
+   *
+   *     // Operation#promise starts polling for the completion of the LRO.
+   *     return operation.promise();
+   *   })
+   *   .then(responses => {
+   *     // The final result of the operation.
+   *     var result = responses[0];
+   *
+   *     // The metadata value of the completed operation.
+   *     var metadata = responses[1];
+   *
+   *     // The response of the api call returning the complete operation.
+   *     var finalApiResponse = responses[2];
+   *   })
+   *   .catch(err => {
+   *     console.error(err);
+   *   });
+   *
+   * var inputUri = 'gs://demomaker/cat.mp4';
+   * var featuresElement = 'LABEL_DETECTION';
+   * var features = [featuresElement];
+   * var request = {
+   *   inputUri: inputUri,
+   *   features: features,
+   * };
+   *
+   * // Handle the operation using the event emitter pattern.
+   * client.annotateVideo(request)
+   *   .then(responses => {
+   *     var operation = responses[0];
+   *     var initialApiResponse = responses[1];
+   *
+   *     // Adding a listener for the "complete" event starts polling for the
+   *     // completion of the operation.
+   *     operation.on('complete', (result, metadata, finalApiResponse) => {
+   *       // doSomethingWith(result);
+   *     });
+   *
+   *     // Adding a listener for the "progress" event causes the callback to be
+   *     // called on any change in metadata when the operation is polled.
+   *     operation.on('progress', (metadata, apiResponse) => {
+   *       // doSomethingWith(metadata)
+   *     });
+   *
+   *     // Adding a listener for the "error" event handles any errors found during polling.
+   *     operation.on('error', err => {
+   *       // throw(err);
+   *     });
+   *   })
+   *   .catch(err => {
+   *     console.error(err);
+   *   });
+   */
+  annotateVideo(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.annotateVideo(request, options, callback);
+  }
+}
+
+module.exports = VideoIntelligenceServiceClient;

--- a/src/v1p1beta1/video_intelligence_service_client_config.json
+++ b/src/v1p1beta1/video_intelligence_service_client_config.json
@@ -1,0 +1,31 @@
+{
+  "interfaces": {
+    "google.cloud.videointelligence.v1p1beta1.VideoIntelligenceService": {
+      "retry_codes": {
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": []
+      },
+      "retry_params": {
+        "default": {
+          "initial_retry_delay_millis": 1000,
+          "retry_delay_multiplier": 2.5,
+          "max_retry_delay_millis": 120000,
+          "initial_rpc_timeout_millis": 120000,
+          "rpc_timeout_multiplier": 1.0,
+          "max_rpc_timeout_millis": 120000,
+          "total_timeout_millis": 600000
+        }
+      },
+      "methods": {
+        "AnnotateVideo": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        }
+      }
+    }
+  }
+}

--- a/system-test/video_intelligence_service_smoke_test.js
+++ b/system-test/video_intelligence_service_smoke_test.js
@@ -1,0 +1,103 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+describe('VideoIntelligenceServiceSmokeTest', () => {
+  it('successfully makes a call to the service', done => {
+    const videoIntelligence = require('../src');
+
+    var client = new videoIntelligence.v1p1beta1.VideoIntelligenceServiceClient({
+      // optional auth parameters.
+    });
+
+    var inputUri = 'gs://demomaker/cat.mp4';
+    var featuresElement = 'LABEL_DETECTION';
+    var features = [featuresElement];
+    var request = {
+      inputUri: inputUri,
+      features: features,
+    };
+
+    // Handle the operation using the promise pattern.
+    client.annotateVideo(request)
+      .then(responses => {
+        var operation = responses[0];
+        var initialApiResponse = responses[1];
+        console.log(operation);
+        console.log(initialApiResponse);
+
+        // Operation#promise starts polling for the completion of the LRO.
+        return operation.promise();
+      })
+      .then(responses => {
+        // The final result of the operation.
+        var result = responses[0];
+
+        // The metadata value of the completed operation.
+        var metadata = responses[1];
+
+        // The response of the api call returning the complete operation.
+        var finalApiResponse = responses[2];
+
+        console.log(result);
+        console.log(metadata);
+        console.log(finalApiResponse);
+      })
+      .then(done)
+      .catch(done);
+  });
+
+  it('successfully makes a call to the service', done => {
+    const videoIntelligence = require('../src');
+
+    var client = new videoIntelligence.v1p1beta1.VideoIntelligenceServiceClient({
+      // optional auth parameters.
+    });
+
+    var inputUri = 'gs://demomaker/cat.mp4';
+    var featuresElement = 'LABEL_DETECTION';
+    var features = [featuresElement];
+    var request = {
+      inputUri: inputUri,
+      features: features,
+    };
+
+    // Handle the operation using the event emitter pattern.
+    client.annotateVideo(request)
+      .then(responses => {
+        var operation = responses[0];
+        var initialApiResponse = responses[1];
+
+        // Adding a listener for the "complete" event starts polling for the
+        // completion of the operation.
+        operation.on('complete', (result, metadata, finalApiResponse) => {
+          console.log(result);
+        });
+
+        // Adding a listener for the "progress" event causes the callback to be
+        // called on any change in metadata when the operation is polled.
+        operation.on('progress', (metadata, apiResponse) => {
+          console.log(metadata);
+        });
+
+        // Adding a listener for the "error" event handles any errors found during polling.
+        operation.on('error', err => {
+          // throw(err);
+        });
+      })
+      .then(done)
+      .catch(done);
+  });
+});

--- a/test/gapic-v1p1beta1.js
+++ b/test/gapic-v1p1beta1.js
@@ -1,0 +1,143 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const assert = require('assert');
+
+const videoIntelligenceModule = require('../src');
+
+var FAKE_STATUS_CODE = 1;
+var error = new Error();
+error.code = FAKE_STATUS_CODE;
+
+describe('VideoIntelligenceServiceClient', () => {
+  describe('annotateVideo', function() {
+    it('invokes annotateVideo without error', done => {
+      var client = new videoIntelligenceModule.v1p1beta1.VideoIntelligenceServiceClient(
+        {
+          credentials: {client_email: 'bogus', private_key: 'bogus'},
+          projectId: 'bogus',
+        }
+      );
+
+      // Mock request
+      var inputUri = 'gs://demomaker/cat.mp4';
+      var featuresElement = 'LABEL_DETECTION';
+      var features = [featuresElement];
+      var request = {
+        inputUri: inputUri,
+        features: features,
+      };
+
+      // Mock response
+      var expectedResponse = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.annotateVideo = mockLongRunningGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client
+        .annotateVideo(request)
+        .then(responses => {
+          var operation = responses[0];
+          return operation.promise();
+        })
+        .then(responses => {
+          assert.deepStrictEqual(responses[0], expectedResponse);
+          done();
+        })
+        .catch(err => {
+          done(err);
+        });
+    });
+
+    it('invokes annotateVideo with error', done => {
+      var client = new videoIntelligenceModule.v1p1beta1.VideoIntelligenceServiceClient(
+        {
+          credentials: {client_email: 'bogus', private_key: 'bogus'},
+          projectId: 'bogus',
+        }
+      );
+
+      // Mock request
+      var inputUri = 'gs://demomaker/cat.mp4';
+      var featuresElement = 'LABEL_DETECTION';
+      var features = [featuresElement];
+      var request = {
+        inputUri: inputUri,
+        features: features,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.annotateVideo = mockLongRunningGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client
+        .annotateVideo(request)
+        .then(responses => {
+          var operation = responses[0];
+          return operation.promise();
+        })
+        .then(() => {
+          assert.fail();
+        })
+        .catch(err => {
+          assert(err instanceof Error);
+          assert.equal(err.code, FAKE_STATUS_CODE);
+          done();
+        });
+    });
+
+    it('has longrunning decoder functions', () => {
+      var client = new videoIntelligenceModule.v1p1beta1.VideoIntelligenceServiceClient(
+        {
+          credentials: {client_email: 'bogus', private_key: 'bogus'},
+          projectId: 'bogus',
+        }
+      );
+      assert(
+        client._descriptors.longrunning.annotateVideo.responseDecoder instanceof
+          Function
+      );
+      assert(
+        client._descriptors.longrunning.annotateVideo.metadataDecoder instanceof
+          Function
+      );
+    });
+  });
+});
+
+function mockLongRunningGrpcMethod(expectedRequest, response, error) {
+  return request => {
+    assert.deepStrictEqual(request, expectedRequest);
+    var mockOperation = {
+      promise: function() {
+        return new Promise((resolve, reject) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve([response]);
+          }
+        });
+      },
+    };
+    return Promise.resolve([mockOperation]);
+  };
+}


### PR DESCRIPTION
Generated GAPIC code for new endpoint `v1p1beta1` which will then be released as v1.1.0 (in a separate PR).

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
