### PR TITLE
release 1.1.0

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,9 +4,8 @@ Please run down the following list and make sure you've tried the usual "quick
 fixes":
 
   - Search the issues already opened: https://github.com/googleapis/nodejs-video-intelligence/issues
+  - Search the issues on our "catch-all" repository: https://github.com/GoogleCloudPlatform/google-cloud-node
   - Search StackOverflow: http://stackoverflow.com/questions/tagged/google-cloud-platform+node.js
-  - Check our Troubleshooting guide: https://googlecloudplatform.github.io/google-cloud-node/#/docs/guides/troubleshooting
-  - Check our FAQ: https://googlecloudplatform.github.io/google-cloud-node/#/docs/guides/faq
 
 If you are still having issues, please be sure to include as much information as
 possible:
@@ -16,7 +15,7 @@ possible:
   - OS:
   - Node.js version:
   - npm version:
-  - @google-cloud/video-intelligence version:
+  - `@google-cloud/video-intelligence` version:
 
 #### Steps to reproduce
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ out/
 system-test/secrets.js
 system-test/*key.json
 *.lock
-*-lock.js*

--- a/.mailmap
+++ b/.mailmap
@@ -4,3 +4,5 @@ Jason Dobry <jdobry@google.com> Jason Dobry <jmdobry@users.noreply.github.com>
 Luke Sneeringer <lukesneeringer@google.com> Luke Sneeringer <luke@sneeringer.com>
 Stephen Sawchuk <sawchuk@gmail.com> Stephen Sawchuk <stephenplusplus@users.noreply.github.com>
 Stephen Sawchuk <sawchuk@gmail.com> Stephen Sawchuk <stephenplusplusplus@gmail.com>
+Stephen Sawchuk <sawchuk@gmail.com> Stephen <stephenplusplus@users.noreply.github.com>
+Alexander Fenster <fenster@google.com> Alexander Fenster <github@fenster.name>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,6 +4,7 @@
 #   name <email>
 #
 Ace Nassri <anassri@google.com>
+Alexander Fenster <fenster@google.com>
 Ali Ijaz Sheikh <ofrobots@google.com>
 Evawere Ogbe <eoogbe@google.com>
 Gus Class <class@google.com>
@@ -12,3 +13,5 @@ Luke Sneeringer <lukesneeringer@google.com>
 Song Wang <songwang@google.com>
 Stephen Sawchuk <sawchuk@gmail.com>
 Tim Swast <swast@google.com>
+greenkeeper[bot] <greenkeeper[bot]@users.noreply.github.com>
+remi Taylor <remi@remitaylor.com>

--- a/README.md
+++ b/README.md
@@ -164,4 +164,4 @@ See [LICENSE](https://github.com/googleapis/nodejs-video-intelligence/blob/maste
 
 [client-docs]: https://cloud.google.com/nodejs/docs/reference/video-intelligence/latest/
 [product-docs]: https://cloud.google.com/video-intelligence
-[shell_img]: http://gstatic.com/cloudssh/images/open-btn.png
+[shell_img]: //gstatic.com/cloudssh/images/open-btn.png

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/video-intelligence",
   "description": "Google Cloud Video Intelligence API client for Node.js",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "Apache-2.0",
   "author": "Google Inc",
   "engines": {
@@ -30,6 +30,7 @@
   ],
   "contributors": [
     "Ace Nassri <anassri@google.com>",
+    "Alexander Fenster <fenster@google.com>",
     "Ali Ijaz Sheikh <ofrobots@google.com>",
     "Evawere Ogbe <eoogbe@google.com>",
     "Gus Class <class@google.com>",
@@ -37,7 +38,9 @@
     "Luke Sneeringer <lukesneeringer@google.com>",
     "Song Wang <songwang@google.com>",
     "Stephen Sawchuk <sawchuk@gmail.com>",
-    "Tim Swast <swast@google.com>"
+    "Tim Swast <swast@google.com>",
+    "greenkeeper[bot] <greenkeeper[bot]@users.noreply.github.com>",
+    "remi Taylor <remi@remitaylor.com>"
   ],
   "scripts": {
     "cover": "nyc --reporter=lcov mocha --require intelli-espower-loader test/*.js && nyc report",

--- a/samples/README.md
+++ b/samples/README.md
@@ -29,16 +29,21 @@ View the [source code][video_0_code].
 __Usage:__ `node analyze.js --help`
 
 ```
+analyze.js <command>
+
 Commands:
-  faces <gcsUri>        Analyzes faces in a video stored in Google Cloud Storage using the Cloud Video Intelligence API.
-  shots <gcsUri>        Analyzes shot angles in a video stored in Google Cloud Storage using the Cloud Video
-                        Intelligence API.
-  labels-gcs <gcsUri>   Labels objects in a video stored in Google Cloud Storage using the Cloud Video Intelligence API.
-  labels-file <gcsUri>  Labels objects in a video stored locally using the Cloud Video Intelligence API.
-  safe-search <gcsUri>  Detects explicit content in a video stored in Google Cloud Storage.
+  analyze.js faces <gcsUri>          Analyzes faces in a video stored in Google Cloud Storage using the Cloud Video
+                                     Intelligence API.
+  analyze.js shots <gcsUri>          Analyzes shot angles in a video stored in Google Cloud Storage using the Cloud
+                                     Video Intelligence API.
+  analyze.js labels-gcs <gcsUri>     Labels objects in a video stored in Google Cloud Storage using the Cloud Video
+                                     Intelligence API.
+  analyze.js labels-file <filePath>  Labels objects in a video stored locally using the Cloud Video Intelligence API.
+  analyze.js safe-search <gcsUri>    Detects explicit content in a video stored in Google Cloud Storage.
 
 Options:
-  --help  Show help                                                                                            [boolean]
+  --version  Show version number                                                                               [boolean]
+  --help     Show help                                                                                         [boolean]
 
 Examples:
   node analyze.js faces gs://demomaker/larry_sergey_ice_bucket_short.mp4
@@ -53,5 +58,5 @@ For more information, see https://cloud.google.com/video-intelligence/docs
 [video_0_docs]: https://cloud.google.com/video-intelligence/docs
 [video_0_code]: analyze.js
 
-[shell_img]: http://gstatic.com/cloudssh/images/open-btn.png
+[shell_img]: //gstatic.com/cloudssh/images/open-btn.png
 [shell_link]: https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-video-intelligence&page=editor&open_in_editor=samples/README.md

--- a/samples/package.json
+++ b/samples/package.json
@@ -14,7 +14,7 @@
     "test": "repo-tools test run --cmd ava -- -T 5m --verbose system-test/*.test.js"
   },
   "dependencies": {
-    "@google-cloud/video-intelligence": "^1.0.0",
+    "@google-cloud/video-intelligence": "1.1.0",
     "long": "^3.2.0",
     "safe-buffer": "5.1.1",
     "yargs": "10.0.3"


### PR DESCRIPTION
Releasing v1.1.0.

---
## Features

This release enables the new endpoint `v1p1beta1` that you can use as shown here:
```js
const video = require('@google-cloud/video-intelligence').v1p1beta1;
```
The default endpoint still points to `v1`, so unless you want to test the new functionality, there is no need to change your code.


---

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
