### PR TITLE
refactor(samples): convert sample tests from ava to mocha

### DIFF
--- a/samples/.eslintrc.yml
+++ b/samples/.eslintrc.yml
@@ -1,3 +1,5 @@
 ---
+env:
+  mocha: true
 rules:
   no-console: off

--- a/samples/package.json
+++ b/samples/package.json
@@ -13,7 +13,6 @@
     "node": ">=8"
   },
   "scripts": {
-    "cover": "nyc --reporter=lcov --cache mocha ./system-test/*.test.js --timeout=600000 && nyc report",
     "test": "mocha system-test/*.test.js --timeout=600000"
   },
   "dependencies": {

--- a/samples/package.json
+++ b/samples/package.json
@@ -13,8 +13,8 @@
     "node": ">=8"
   },
   "scripts": {
-    "cover": "nyc --reporter=lcov --cache ava -T 20s --verbose test/*.test.js ./system-test/*.test.js && nyc report",
-    "test": "ava -T 10m --serial --verbose system-test/*.test.js"
+    "cover": "nyc --reporter=lcov --cache mocha ./system-test/*.test.js --timeout=600000 && nyc report",
+    "test": "mocha system-test/*.test.js --timeout=600000"
   },
   "dependencies": {
     "@google-cloud/video-intelligence": "^1.5.0",

--- a/samples/system-test/analyze.test.js
+++ b/samples/system-test/analyze.test.js
@@ -18,7 +18,7 @@
 'use strict';
 
 const path = require(`path`);
-const test = require(`ava`);
+const assert = require(`assert`);
 const tools = require(`@google-cloud/nodejs-repo-tools`);
 
 const cmd = `node analyze.js`;
@@ -29,59 +29,59 @@ const shortUrl = `gs://nodejs-docs-samples-video/quickstart_short.mp4`;
 const file = `resources/cat.mp4`;
 
 // analyze_labels_gcs (one scene)
-test.serial(`should analyze labels in a GCS file with one scene`, async t => {
+it(`should analyze labels in a GCS file with one scene`, async () => {
   const output = await tools.runAsync(`${cmd} labels-gcs ${shortUrl}`, cwd);
-  t.regex(output, /Label shirt occurs at:/);
-  t.regex(output, /Confidence: \d+\.\d+/);
+  assert.strictEqual(new RegExp(/Label shirt occurs at:/).test(output), true);
+  assert.strictEqual(new RegExp(/Confidence: \d+\.\d+/).test(output), true);
 });
 
 // analyze_labels_gcs (multiple scenes)
-test.serial(
+it(
   `should analyze labels in a GCS file with multiple scenes`,
-  async t => {
+  async () => {
     const output = await tools.runAsync(`${cmd} labels-gcs ${url}`, cwd);
-    t.regex(output, /Label shirt occurs at:/);
-    t.regex(output, /Confidence: \d+\.\d+/);
+    assert.strictEqual(new RegExp(/Label shirt occurs at:/).test(output), true);
+    assert.strictEqual(new RegExp(/Confidence: \d+\.\d+/).test(output), true);
   }
 );
 
 // analyze_labels_local
-test.serial(`should analyze labels in a local file`, async t => {
+it(`should analyze labels in a local file`, async () => {
   const output = await tools.runAsync(`${cmd} labels-file ${file}`, cwd);
-  t.regex(output, /Label whiskers occurs at:/);
-  t.regex(output, /Confidence: \d+\.\d+/);
+  assert.strictEqual(new RegExp(/Label whiskers occurs at:/).test(output), true);
+  assert.strictEqual(new RegExp(/Confidence: \d+\.\d+/).test(output), true);
 });
 
 // analyze_shots (multiple shots)
-test.serial(
+it(
   `should analyze shots in a GCS file with multiple shots`,
-  async t => {
+  async () => {
     const output = await tools.runAsync(`${cmd} shots ${url}`, cwd);
-    t.regex(output, /Scene 0 occurs from:/);
+    assert.strictEqual(new RegExp(/Scene 0 occurs from:/).test(output), true);
   }
 );
 
 // analyze_shots (one shot)
-test.serial(`should analyze shots in a GCS file with one shot`, async t => {
+it(`should analyze shots in a GCS file with one shot`, async () => {
   const output = await tools.runAsync(`${cmd} shots ${shortUrl}`, cwd);
-  t.regex(output, /The entire video is one shot./);
+  assert.strictEqual(new RegExp(/The entire video is one shot./).test(output), true);
 });
 
 // analyze_safe_search
-test.serial(`should analyze safe search results in a GCS file`, async t => {
+it(`should analyze safe search results in a GCS file`, async () => {
   const output = await tools.runAsync(`${cmd} safe-search ${url}`, cwd);
-  t.regex(output, /Time: \d+\.\d+s/);
-  t.regex(output, /Explicit annotation results:/);
+  assert.strictEqual(new RegExp(/Time: \d+\.\d+s/).test(output), true);
+  assert.strictEqual(new RegExp(/Explicit annotation results:/).test(output), true);
 });
 
 // analyze_video_transcription
-test.serial(
+it(
   `should analyze video transcription results in a GCS file`,
-  async t => {
+  async () => {
     const output = await tools.runAsync(
       `${cmd} transcription ${shortUrl}`,
       cwd
     );
-    t.regex(output, /over the pass/);
+    assert.strictEqual(new RegExp(/over the pass/).test(output), true);
   }
 );

--- a/samples/system-test/analyze.test.js
+++ b/samples/system-test/analyze.test.js
@@ -1,13 +1,13 @@
 /**
  * Copyright 2017, Google, Inc.
- * Licensed under the Apache License, Version 2.0 (the `License`);
+ * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an `AS IS` BASIS,
+ * distributed under the License is distributed on an 'AS IS' BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
@@ -17,33 +17,33 @@
 
 'use strict';
 
-const path = require(`path`);
-const assert = require(`assert`);
-const tools = require(`@google-cloud/nodejs-repo-tools`);
+const path = require('path');
+const assert = require('assert');
+const tools = require('@google-cloud/nodejs-repo-tools');
 
-const cmd = `node analyze.js`;
-const cwd = path.join(__dirname, `..`);
+const cmd = 'node analyze.js';
+const cwd = path.join(__dirname, '..');
 
-const url = `gs://nodejs-docs-samples-video/quickstart.mp4`;
-const shortUrl = `gs://nodejs-docs-samples-video/quickstart_short.mp4`;
-const file = `resources/cat.mp4`;
+const url = 'gs://nodejs-docs-samples-video/quickstart.mp4';
+const shortUrl = 'gs://nodejs-docs-samples-video/quickstart_short.mp4';
+const file = 'resources/cat.mp4';
 
 // analyze_labels_gcs (one scene)
-it(`should analyze labels in a GCS file with one scene`, async () => {
+it('should analyze labels in a GCS file with one scene', async () => {
   const output = await tools.runAsync(`${cmd} labels-gcs ${shortUrl}`, cwd);
   assert.strictEqual(new RegExp(/Label shirt occurs at:/).test(output), true);
   assert.strictEqual(new RegExp(/Confidence: \d+\.\d+/).test(output), true);
 });
 
 // analyze_labels_gcs (multiple scenes)
-it(`should analyze labels in a GCS file with multiple scenes`, async () => {
+it('should analyze labels in a GCS file with multiple scenes', async () => {
   const output = await tools.runAsync(`${cmd} labels-gcs ${url}`, cwd);
   assert.strictEqual(new RegExp(/Label shirt occurs at:/).test(output), true);
   assert.strictEqual(new RegExp(/Confidence: \d+\.\d+/).test(output), true);
 });
 
 // analyze_labels_local
-it(`should analyze labels in a local file`, async () => {
+it('should analyze labels in a local file', async () => {
   const output = await tools.runAsync(`${cmd} labels-file ${file}`, cwd);
   assert.strictEqual(
     new RegExp(/Label whiskers occurs at:/).test(output),
@@ -53,13 +53,13 @@ it(`should analyze labels in a local file`, async () => {
 });
 
 // analyze_shots (multiple shots)
-it(`should analyze shots in a GCS file with multiple shots`, async () => {
+it('should analyze shots in a GCS file with multiple shots', async () => {
   const output = await tools.runAsync(`${cmd} shots ${url}`, cwd);
   assert.strictEqual(new RegExp(/Scene 0 occurs from:/).test(output), true);
 });
 
 // analyze_shots (one shot)
-it(`should analyze shots in a GCS file with one shot`, async () => {
+it('should analyze shots in a GCS file with one shot', async () => {
   const output = await tools.runAsync(`${cmd} shots ${shortUrl}`, cwd);
   assert.strictEqual(
     new RegExp(/The entire video is one shot./).test(output),
@@ -68,7 +68,7 @@ it(`should analyze shots in a GCS file with one shot`, async () => {
 });
 
 // analyze_safe_search
-it(`should analyze safe search results in a GCS file`, async () => {
+it('should analyze safe search results in a GCS file', async () => {
   const output = await tools.runAsync(`${cmd} safe-search ${url}`, cwd);
   assert.strictEqual(new RegExp(/Time: \d+\.\d+s/).test(output), true);
   assert.strictEqual(
@@ -78,7 +78,7 @@ it(`should analyze safe search results in a GCS file`, async () => {
 });
 
 // analyze_video_transcription
-it(`should analyze video transcription results in a GCS file`, async () => {
+it('should analyze video transcription results in a GCS file', async () => {
   const output = await tools.runAsync(`${cmd} transcription ${shortUrl}`, cwd);
   assert.strictEqual(new RegExp(/over the pass/).test(output), true);
 });

--- a/samples/system-test/analyze.test.js
+++ b/samples/system-test/analyze.test.js
@@ -36,52 +36,49 @@ it(`should analyze labels in a GCS file with one scene`, async () => {
 });
 
 // analyze_labels_gcs (multiple scenes)
-it(
-  `should analyze labels in a GCS file with multiple scenes`,
-  async () => {
-    const output = await tools.runAsync(`${cmd} labels-gcs ${url}`, cwd);
-    assert.strictEqual(new RegExp(/Label shirt occurs at:/).test(output), true);
-    assert.strictEqual(new RegExp(/Confidence: \d+\.\d+/).test(output), true);
-  }
-);
+it(`should analyze labels in a GCS file with multiple scenes`, async () => {
+  const output = await tools.runAsync(`${cmd} labels-gcs ${url}`, cwd);
+  assert.strictEqual(new RegExp(/Label shirt occurs at:/).test(output), true);
+  assert.strictEqual(new RegExp(/Confidence: \d+\.\d+/).test(output), true);
+});
 
 // analyze_labels_local
 it(`should analyze labels in a local file`, async () => {
   const output = await tools.runAsync(`${cmd} labels-file ${file}`, cwd);
-  assert.strictEqual(new RegExp(/Label whiskers occurs at:/).test(output), true);
+  assert.strictEqual(
+    new RegExp(/Label whiskers occurs at:/).test(output),
+    true
+  );
   assert.strictEqual(new RegExp(/Confidence: \d+\.\d+/).test(output), true);
 });
 
 // analyze_shots (multiple shots)
-it(
-  `should analyze shots in a GCS file with multiple shots`,
-  async () => {
-    const output = await tools.runAsync(`${cmd} shots ${url}`, cwd);
-    assert.strictEqual(new RegExp(/Scene 0 occurs from:/).test(output), true);
-  }
-);
+it(`should analyze shots in a GCS file with multiple shots`, async () => {
+  const output = await tools.runAsync(`${cmd} shots ${url}`, cwd);
+  assert.strictEqual(new RegExp(/Scene 0 occurs from:/).test(output), true);
+});
 
 // analyze_shots (one shot)
 it(`should analyze shots in a GCS file with one shot`, async () => {
   const output = await tools.runAsync(`${cmd} shots ${shortUrl}`, cwd);
-  assert.strictEqual(new RegExp(/The entire video is one shot./).test(output), true);
+  assert.strictEqual(
+    new RegExp(/The entire video is one shot./).test(output),
+    true
+  );
 });
 
 // analyze_safe_search
 it(`should analyze safe search results in a GCS file`, async () => {
   const output = await tools.runAsync(`${cmd} safe-search ${url}`, cwd);
   assert.strictEqual(new RegExp(/Time: \d+\.\d+s/).test(output), true);
-  assert.strictEqual(new RegExp(/Explicit annotation results:/).test(output), true);
+  assert.strictEqual(
+    new RegExp(/Explicit annotation results:/).test(output),
+    true
+  );
 });
 
 // analyze_video_transcription
-it(
-  `should analyze video transcription results in a GCS file`,
-  async () => {
-    const output = await tools.runAsync(
-      `${cmd} transcription ${shortUrl}`,
-      cwd
-    );
-    assert.strictEqual(new RegExp(/over the pass/).test(output), true);
-  }
-);
+it(`should analyze video transcription results in a GCS file`, async () => {
+  const output = await tools.runAsync(`${cmd} transcription ${shortUrl}`, cwd);
+  assert.strictEqual(new RegExp(/over the pass/).test(output), true);
+});

--- a/samples/system-test/analyze.v1p2beta1.test.js
+++ b/samples/system-test/analyze.v1p2beta1.test.js
@@ -1,13 +1,13 @@
 /**
  * Copyright 2018, Google, LLC
- * Licensed under the Apache License, Version 2.0 (the `License`);
+ * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an `AS IS` BASIS,
+ * distributed under the License is distributed on an 'AS IS' BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
@@ -17,36 +17,36 @@
 
 'use strict';
 
-const path = require(`path`);
-const assert = require(`assert`);
-const tools = require(`@google-cloud/nodejs-repo-tools`);
+const path = require('path');
+const assert = require('assert');
+const tools = require('@google-cloud/nodejs-repo-tools');
 
-const cmd = `node analyze.v1p2beta1.js`;
-const cwd = path.join(__dirname, `..`);
+const cmd = 'node analyze.v1p2beta1.js';
+const cwd = path.join(__dirname, '..');
 
-const shortUrl = `gs://nodejs-docs-samples/video/googlework_short.mp4`;
-const url = `gs://nodejs-docs-samples/video/cat.mp4`;
-const file1 = `resources/cat.mp4`;
-const file2 = `resources/googlework_short.mp4`;
+const shortUrl = 'gs://nodejs-docs-samples/video/googlework_short.mp4';
+const url = 'gs://nodejs-docs-samples/video/cat.mp4';
+const file1 = 'resources/cat.mp4';
+const file2 = 'resources/googlework_short.mp4';
 const possibleTexts = /Google|GOOGLE|SUR|OMAR|ROTO|Vice President|58oo9|LONDRES|PARIS|METRO|RUE|CARLO/;
 
-it(`should detect text in a GCS file`, async () => {
+it('should detect text in a GCS file', async () => {
   const output = await tools.runAsync(`${cmd} video-text-gcs ${shortUrl}`, cwd);
   assert.strictEqual(new RegExp(possibleTexts).test(output), true);
 });
 
-it(`should detect text in a local file`, async () => {
+it('should detect text in a local file', async () => {
   const output = await tools.runAsync(`${cmd} video-text ${file2}`, cwd);
   assert.strictEqual(new RegExp(possibleTexts).test(output), true);
 });
 
-it(`should track objects in a GCS file`, async () => {
+it('should track objects in a GCS file', async () => {
   const output = await tools.runAsync(`${cmd} track-objects-gcs ${url}`, cwd);
   assert.strictEqual(new RegExp(/cat/).test(output), true);
   assert.strictEqual(new RegExp(/Confidence: \d+\.\d+/).test(output), true);
 });
 
-it(`should track objects in a local file`, async () => {
+it('should track objects in a local file', async () => {
   const output = await tools.runAsync(`${cmd} track-objects ${file1}`, cwd);
   assert.strictEqual(new RegExp(/cat/).test(output), true);
   assert.strictEqual(new RegExp(/Confidence: \d+\.\d+/).test(output), true);

--- a/samples/system-test/analyze.v1p2beta1.test.js
+++ b/samples/system-test/analyze.v1p2beta1.test.js
@@ -18,7 +18,7 @@
 'use strict';
 
 const path = require(`path`);
-const test = require(`ava`);
+const assert = require(`assert`);
 const tools = require(`@google-cloud/nodejs-repo-tools`);
 
 const cmd = `node analyze.v1p2beta1.js`;
@@ -30,24 +30,24 @@ const file1 = `resources/cat.mp4`;
 const file2 = `resources/googlework_short.mp4`;
 const possibleTexts = /Google|GOOGLE|SUR|OMAR|ROTO|Vice President|58oo9|LONDRES|PARIS|METRO|RUE|CARLO/;
 
-test.serial(`should detect text in a GCS file`, async t => {
+it(`should detect text in a GCS file`, async () => {
   const output = await tools.runAsync(`${cmd} video-text-gcs ${shortUrl}`, cwd);
-  t.regex(output, possibleTexts);
+  assert.strictEqual(new RegExp(possibleTexts).test(output), true);
 });
 
-test.serial(`should detect text in a local file`, async t => {
+it(`should detect text in a local file`, async () => {
   const output = await tools.runAsync(`${cmd} video-text ${file2}`, cwd);
-  t.regex(output, possibleTexts);
+  assert.strictEqual(new RegExp(possibleTexts).test(output), true);
 });
 
-test.serial(`should track objects in a GCS file`, async t => {
+it(`should track objects in a GCS file`, async () => {
   const output = await tools.runAsync(`${cmd} track-objects-gcs ${url}`, cwd);
-  t.regex(output, /cat/);
-  t.regex(output, /Confidence: \d+\.\d+/);
+  assert.strictEqual(new RegExp(/cat/).test(output), true);
+  assert.strictEqual(new RegExp(/Confidence: \d+\.\d+/).test(output), true);
 });
 
-test.serial(`should track objects in a local file`, async t => {
+it(`should track objects in a local file`, async () => {
   const output = await tools.runAsync(`${cmd} track-objects ${file1}`, cwd);
-  t.regex(output, /cat/);
-  t.regex(output, /Confidence: \d+\.\d+/);
+  assert.strictEqual(new RegExp(/cat/).test(output), true);
+  assert.strictEqual(new RegExp(/Confidence: \d+\.\d+/).test(output), true);
 });

--- a/samples/system-test/quickstart.test.js
+++ b/samples/system-test/quickstart.test.js
@@ -16,13 +16,16 @@
 'use strict';
 
 const path = require(`path`);
-const test = require(`ava`);
+const assert = require(`assert`);
 const tools = require(`@google-cloud/nodejs-repo-tools`);
 
 const cmd = `node quickstart.js`;
 const cwd = path.join(__dirname, `..`);
 
-test(`should analyze a hardcoded video`, async t => {
+it(`should analyze a hardcoded video`, async () => {
   const output = await tools.runAsync(cmd, cwd);
-  t.regex(output, /Label standing occurs at:/);
+  assert.strictEqual(
+    new RegExp(/Label standing occurs at:/).test(output),
+    true
+  );
 });

--- a/samples/system-test/quickstart.test.js
+++ b/samples/system-test/quickstart.test.js
@@ -15,14 +15,14 @@
 
 'use strict';
 
-const path = require(`path`);
-const assert = require(`assert`);
-const tools = require(`@google-cloud/nodejs-repo-tools`);
+const path = require('path');
+const assert = require('assert');
+const tools = require('@google-cloud/nodejs-repo-tools');
 
-const cmd = `node quickstart.js`;
-const cwd = path.join(__dirname, `..`);
+const cmd = 'node quickstart.js';
+const cwd = path.join(__dirname, '..');
 
-it(`should analyze a hardcoded video`, async () => {
+it('should analyze a hardcoded video', async () => {
   const output = await tools.runAsync(cmd, cwd);
   assert.strictEqual(
     new RegExp(/Label standing occurs at:/).test(output),


### PR DESCRIPTION
Fixes convert all sample tests from ava to mocha #[2865](https://github.com/googleapis/google-cloud-node/issues/2865)  (it's a good idea to open an issue first for discussion)

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
