### PR TITLE
docs(samples): Adds start of region tag

### DIFF
--- a/samples/analyze-streaming-labels.js
+++ b/samples/analyze-streaming-labels.js
@@ -16,6 +16,7 @@
 'use strict';
 
 async function main(path = 'YOUR_LOCAL_FILE') {
+  // [START video_streaming_label_detection_beta]
   /**
    * TODO(developer): Uncomment these variables before running the sample.
    */


### PR DESCRIPTION
This sample needs a matching [START video_streaming_label_detection_beta] for the   [END video_streaming_label_detection_beta]

Fixes #<issue_number_goes_here> (it's a good idea to open an issue first for discussion)

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
