### PR TITLE
feat: check status of long running operation by its name

### DIFF
--- a/src/v1/video_intelligence_service_client.ts
+++ b/src/v1/video_intelligence_service_client.ts
@@ -28,7 +28,7 @@ import * as path from 'path';
 
 import * as protos from '../../protos/protos';
 import * as gapicConfig from './video_intelligence_service_client_config.json';
-
+import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -429,6 +429,42 @@ export class VideoIntelligenceServiceClient {
     options = options || {};
     this.initialize();
     return this.innerApiCalls.annotateVideo(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the annotateVideo() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkAnnotateVideoProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkAnnotateVideoProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.cloud.videointelligence.v1.AnnotateVideoResponse,
+      protos.google.cloud.videointelligence.v1.AnnotateVideoProgress
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.annotateVideo,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.cloud.videointelligence.v1.AnnotateVideoResponse,
+      protos.google.cloud.videointelligence.v1.AnnotateVideoProgress
+    >;
   }
 
   /**

--- a/src/v1beta2/video_intelligence_service_client.ts
+++ b/src/v1beta2/video_intelligence_service_client.ts
@@ -28,7 +28,7 @@ import * as path from 'path';
 
 import * as protos from '../../protos/protos';
 import * as gapicConfig from './video_intelligence_service_client_config.json';
-
+import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -429,6 +429,42 @@ export class VideoIntelligenceServiceClient {
     options = options || {};
     this.initialize();
     return this.innerApiCalls.annotateVideo(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the annotateVideo() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkAnnotateVideoProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkAnnotateVideoProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.cloud.videointelligence.v1beta2.AnnotateVideoResponse,
+      protos.google.cloud.videointelligence.v1beta2.AnnotateVideoProgress
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.annotateVideo,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.cloud.videointelligence.v1beta2.AnnotateVideoResponse,
+      protos.google.cloud.videointelligence.v1beta2.AnnotateVideoProgress
+    >;
   }
 
   /**

--- a/src/v1p1beta1/video_intelligence_service_client.ts
+++ b/src/v1p1beta1/video_intelligence_service_client.ts
@@ -28,7 +28,7 @@ import * as path from 'path';
 
 import * as protos from '../../protos/protos';
 import * as gapicConfig from './video_intelligence_service_client_config.json';
-
+import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -429,6 +429,42 @@ export class VideoIntelligenceServiceClient {
     options = options || {};
     this.initialize();
     return this.innerApiCalls.annotateVideo(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the annotateVideo() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkAnnotateVideoProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkAnnotateVideoProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.cloud.videointelligence.v1p1beta1.AnnotateVideoResponse,
+      protos.google.cloud.videointelligence.v1p1beta1.AnnotateVideoProgress
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.annotateVideo,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.cloud.videointelligence.v1p1beta1.AnnotateVideoResponse,
+      protos.google.cloud.videointelligence.v1p1beta1.AnnotateVideoProgress
+    >;
   }
 
   /**

--- a/src/v1p2beta1/video_intelligence_service_client.ts
+++ b/src/v1p2beta1/video_intelligence_service_client.ts
@@ -28,7 +28,7 @@ import * as path from 'path';
 
 import * as protos from '../../protos/protos';
 import * as gapicConfig from './video_intelligence_service_client_config.json';
-
+import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -429,6 +429,42 @@ export class VideoIntelligenceServiceClient {
     options = options || {};
     this.initialize();
     return this.innerApiCalls.annotateVideo(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the annotateVideo() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkAnnotateVideoProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkAnnotateVideoProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.cloud.videointelligence.v1p2beta1.AnnotateVideoResponse,
+      protos.google.cloud.videointelligence.v1p2beta1.AnnotateVideoProgress
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.annotateVideo,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.cloud.videointelligence.v1p2beta1.AnnotateVideoResponse,
+      protos.google.cloud.videointelligence.v1p2beta1.AnnotateVideoProgress
+    >;
   }
 
   /**

--- a/src/v1p3beta1/video_intelligence_service_client.ts
+++ b/src/v1p3beta1/video_intelligence_service_client.ts
@@ -28,7 +28,7 @@ import * as path from 'path';
 
 import * as protos from '../../protos/protos';
 import * as gapicConfig from './video_intelligence_service_client_config.json';
-
+import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -429,6 +429,42 @@ export class VideoIntelligenceServiceClient {
     options = options || {};
     this.initialize();
     return this.innerApiCalls.annotateVideo(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the annotateVideo() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkAnnotateVideoProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkAnnotateVideoProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.cloud.videointelligence.v1p3beta1.AnnotateVideoResponse,
+      protos.google.cloud.videointelligence.v1p3beta1.AnnotateVideoProgress
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.annotateVideo,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.cloud.videointelligence.v1p3beta1.AnnotateVideoResponse,
+      protos.google.cloud.videointelligence.v1p3beta1.AnnotateVideoProgress
+    >;
   }
 
   /**

--- a/synth.metadata
+++ b/synth.metadata
@@ -3,23 +3,23 @@
     {
       "git": {
         "name": ".",
-        "remote": "https://github.com/googleapis/nodejs-video-intelligence.git",
-        "sha": "3b5ad804802d391c2e1d1e575b700d3d69391ef5"
+        "remote": "git@github.com:googleapis/nodejs-video-intelligence.git",
+        "sha": "1c520fcba901d09902dc7f1fe73d150c8ddeee00"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "42ee97c1b93a0e3759bbba3013da309f670a90ab",
-        "internalRef": "307114445"
+        "sha": "a3a0bf0f6291d69f2ff3df7fcd63d28ee20ac727",
+        "internalRef": "310060413"
       }
     },
     {
       "git": {
         "name": "synthtool",
         "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "19465d3ec5e5acdb01521d8f3bddd311bcbee28d"
+        "sha": "ab883569eb0257bbf16a6d825fd018b3adde3912"
       }
     }
   ],

--- a/test/gapic_streaming_video_intelligence_service_v1p3beta1.ts
+++ b/test/gapic_streaming_video_intelligence_service_v1p3beta1.ts
@@ -229,9 +229,7 @@ describe('v1p3beta1.StreamingVideoIntelligenceServiceClient', () => {
         stream.write(request);
         stream.end();
       });
-      await assert.rejects(async () => {
-        await promise;
-      }, expectedError);
+      await assert.rejects(promise, expectedError);
       assert(
         (client.innerApiCalls.streamingAnnotateVideo as SinonStub)
           .getCall(0)

--- a/test/gapic_video_intelligence_service_v1.ts
+++ b/test/gapic_video_intelligence_service_v1.ts
@@ -23,7 +23,7 @@ import {SinonStub} from 'sinon';
 import {describe, it} from 'mocha';
 import * as videointelligenceserviceModule from '../src';
 
-import {protobuf, LROperation} from 'google-gax';
+import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (instance.constructor as typeof protobuf.Message).toObject(
@@ -33,6 +33,21 @@ function generateSampleMessage<T extends object>(instance: T) {
   return (instance.constructor as typeof protobuf.Message).fromObject(
     filledObject
   ) as T;
+}
+
+function stubSimpleCall<ResponseType>(response?: ResponseType, error?: Error) {
+  return error
+    ? sinon.stub().rejects(error)
+    : sinon.stub().resolves([response]);
+}
+
+function stubSimpleCallWithCallback<ResponseType>(
+  response?: ResponseType,
+  error?: Error
+) {
+  return error
+    ? sinon.stub().callsArgWith(2, error)
+    : sinon.stub().callsArgWith(2, null, response);
 }
 
 function stubLongRunningCall<ResponseType>(
@@ -258,9 +273,7 @@ describe('v1.VideoIntelligenceServiceClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.annotateVideo(request);
-      }, expectedError);
+      await assert.rejects(client.annotateVideo(request), expectedError);
       assert(
         (client.innerApiCalls.annotateVideo as SinonStub)
           .getCall(0)
@@ -287,14 +300,57 @@ describe('v1.VideoIntelligenceServiceClient', () => {
         expectedError
       );
       const [operation] = await client.annotateVideo(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.annotateVideo as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkAnnotateVideoProgress without error', async () => {
+      const client = new videointelligenceserviceModule.v1.VideoIntelligenceServiceClient(
+        {
+          credentials: {client_email: 'bogus', private_key: 'bogus'},
+          projectId: 'bogus',
+        }
+      );
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkAnnotateVideoProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkAnnotateVideoProgress with error', async () => {
+      const client = new videointelligenceserviceModule.v1.VideoIntelligenceServiceClient(
+        {
+          credentials: {client_email: 'bogus', private_key: 'bogus'},
+          projectId: 'bogus',
+        }
+      );
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkAnnotateVideoProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 });

--- a/test/gapic_video_intelligence_service_v1beta2.ts
+++ b/test/gapic_video_intelligence_service_v1beta2.ts
@@ -23,7 +23,7 @@ import {SinonStub} from 'sinon';
 import {describe, it} from 'mocha';
 import * as videointelligenceserviceModule from '../src';
 
-import {protobuf, LROperation} from 'google-gax';
+import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (instance.constructor as typeof protobuf.Message).toObject(
@@ -33,6 +33,21 @@ function generateSampleMessage<T extends object>(instance: T) {
   return (instance.constructor as typeof protobuf.Message).fromObject(
     filledObject
   ) as T;
+}
+
+function stubSimpleCall<ResponseType>(response?: ResponseType, error?: Error) {
+  return error
+    ? sinon.stub().rejects(error)
+    : sinon.stub().resolves([response]);
+}
+
+function stubSimpleCallWithCallback<ResponseType>(
+  response?: ResponseType,
+  error?: Error
+) {
+  return error
+    ? sinon.stub().callsArgWith(2, error)
+    : sinon.stub().callsArgWith(2, null, response);
 }
 
 function stubLongRunningCall<ResponseType>(
@@ -259,9 +274,7 @@ describe('v1beta2.VideoIntelligenceServiceClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.annotateVideo(request);
-      }, expectedError);
+      await assert.rejects(client.annotateVideo(request), expectedError);
       assert(
         (client.innerApiCalls.annotateVideo as SinonStub)
           .getCall(0)
@@ -288,14 +301,57 @@ describe('v1beta2.VideoIntelligenceServiceClient', () => {
         expectedError
       );
       const [operation] = await client.annotateVideo(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.annotateVideo as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkAnnotateVideoProgress without error', async () => {
+      const client = new videointelligenceserviceModule.v1beta2.VideoIntelligenceServiceClient(
+        {
+          credentials: {client_email: 'bogus', private_key: 'bogus'},
+          projectId: 'bogus',
+        }
+      );
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkAnnotateVideoProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkAnnotateVideoProgress with error', async () => {
+      const client = new videointelligenceserviceModule.v1beta2.VideoIntelligenceServiceClient(
+        {
+          credentials: {client_email: 'bogus', private_key: 'bogus'},
+          projectId: 'bogus',
+        }
+      );
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkAnnotateVideoProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 });

--- a/test/gapic_video_intelligence_service_v1p1beta1.ts
+++ b/test/gapic_video_intelligence_service_v1p1beta1.ts
@@ -23,7 +23,7 @@ import {SinonStub} from 'sinon';
 import {describe, it} from 'mocha';
 import * as videointelligenceserviceModule from '../src';
 
-import {protobuf, LROperation} from 'google-gax';
+import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (instance.constructor as typeof protobuf.Message).toObject(
@@ -33,6 +33,21 @@ function generateSampleMessage<T extends object>(instance: T) {
   return (instance.constructor as typeof protobuf.Message).fromObject(
     filledObject
   ) as T;
+}
+
+function stubSimpleCall<ResponseType>(response?: ResponseType, error?: Error) {
+  return error
+    ? sinon.stub().rejects(error)
+    : sinon.stub().resolves([response]);
+}
+
+function stubSimpleCallWithCallback<ResponseType>(
+  response?: ResponseType,
+  error?: Error
+) {
+  return error
+    ? sinon.stub().callsArgWith(2, error)
+    : sinon.stub().callsArgWith(2, null, response);
 }
 
 function stubLongRunningCall<ResponseType>(
@@ -259,9 +274,7 @@ describe('v1p1beta1.VideoIntelligenceServiceClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.annotateVideo(request);
-      }, expectedError);
+      await assert.rejects(client.annotateVideo(request), expectedError);
       assert(
         (client.innerApiCalls.annotateVideo as SinonStub)
           .getCall(0)
@@ -288,14 +301,57 @@ describe('v1p1beta1.VideoIntelligenceServiceClient', () => {
         expectedError
       );
       const [operation] = await client.annotateVideo(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.annotateVideo as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkAnnotateVideoProgress without error', async () => {
+      const client = new videointelligenceserviceModule.v1p1beta1.VideoIntelligenceServiceClient(
+        {
+          credentials: {client_email: 'bogus', private_key: 'bogus'},
+          projectId: 'bogus',
+        }
+      );
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkAnnotateVideoProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkAnnotateVideoProgress with error', async () => {
+      const client = new videointelligenceserviceModule.v1p1beta1.VideoIntelligenceServiceClient(
+        {
+          credentials: {client_email: 'bogus', private_key: 'bogus'},
+          projectId: 'bogus',
+        }
+      );
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkAnnotateVideoProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 });

--- a/test/gapic_video_intelligence_service_v1p2beta1.ts
+++ b/test/gapic_video_intelligence_service_v1p2beta1.ts
@@ -23,7 +23,7 @@ import {SinonStub} from 'sinon';
 import {describe, it} from 'mocha';
 import * as videointelligenceserviceModule from '../src';
 
-import {protobuf, LROperation} from 'google-gax';
+import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (instance.constructor as typeof protobuf.Message).toObject(
@@ -33,6 +33,21 @@ function generateSampleMessage<T extends object>(instance: T) {
   return (instance.constructor as typeof protobuf.Message).fromObject(
     filledObject
   ) as T;
+}
+
+function stubSimpleCall<ResponseType>(response?: ResponseType, error?: Error) {
+  return error
+    ? sinon.stub().rejects(error)
+    : sinon.stub().resolves([response]);
+}
+
+function stubSimpleCallWithCallback<ResponseType>(
+  response?: ResponseType,
+  error?: Error
+) {
+  return error
+    ? sinon.stub().callsArgWith(2, error)
+    : sinon.stub().callsArgWith(2, null, response);
 }
 
 function stubLongRunningCall<ResponseType>(
@@ -259,9 +274,7 @@ describe('v1p2beta1.VideoIntelligenceServiceClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.annotateVideo(request);
-      }, expectedError);
+      await assert.rejects(client.annotateVideo(request), expectedError);
       assert(
         (client.innerApiCalls.annotateVideo as SinonStub)
           .getCall(0)
@@ -288,14 +301,57 @@ describe('v1p2beta1.VideoIntelligenceServiceClient', () => {
         expectedError
       );
       const [operation] = await client.annotateVideo(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.annotateVideo as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkAnnotateVideoProgress without error', async () => {
+      const client = new videointelligenceserviceModule.v1p2beta1.VideoIntelligenceServiceClient(
+        {
+          credentials: {client_email: 'bogus', private_key: 'bogus'},
+          projectId: 'bogus',
+        }
+      );
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkAnnotateVideoProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkAnnotateVideoProgress with error', async () => {
+      const client = new videointelligenceserviceModule.v1p2beta1.VideoIntelligenceServiceClient(
+        {
+          credentials: {client_email: 'bogus', private_key: 'bogus'},
+          projectId: 'bogus',
+        }
+      );
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkAnnotateVideoProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 });


### PR DESCRIPTION
For each client method returning a long running operation, a separate method to check its status is added.

Added methods: `checkAnnotateVideoProgress`.