### PR TITLE
chore: Cleanup timestamp setting blocks in samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,18 +91,6 @@ labels.forEach(label => {
   console.log(`Label ${label.entity.description} occurs at:`);
   label.segments.forEach(segment => {
     segment = segment.segment;
-    if (segment.startTimeOffset.seconds === undefined) {
-      segment.startTimeOffset.seconds = 0;
-    }
-    if (segment.startTimeOffset.nanos === undefined) {
-      segment.startTimeOffset.nanos = 0;
-    }
-    if (segment.endTimeOffset.seconds === undefined) {
-      segment.endTimeOffset.seconds = 0;
-    }
-    if (segment.endTimeOffset.nanos === undefined) {
-      segment.endTimeOffset.nanos = 0;
-    }
     console.log(
       `\tStart: ${segment.startTimeOffset.seconds}` +
         `.${(segment.startTimeOffset.nanos / 1e6).toFixed(0)}s`

--- a/samples/analyze-face-detection-gcs.js
+++ b/samples/analyze-face-detection-gcs.js
@@ -53,18 +53,6 @@ function main(gcsUri = 'YOUR_STORAGE_URI') {
       console.log('Face detected:');
 
       for (const {segment, timestampedObjects} of tracks) {
-        if (segment.startTimeOffset.seconds === undefined) {
-          segment.startTimeOffset.seconds = 0;
-        }
-        if (segment.startTimeOffset.nanos === undefined) {
-          segment.startTimeOffset.nanos = 0;
-        }
-        if (segment.endTimeOffset.seconds === undefined) {
-          segment.endTimeOffset.seconds = 0;
-        }
-        if (segment.endTimeOffset.nanos === undefined) {
-          segment.endTimeOffset.nanos = 0;
-        }
         console.log(
           `\tStart: ${segment.startTimeOffset.seconds}.` +
             `${(segment.startTimeOffset.nanos / 1e6).toFixed(0)}s`

--- a/samples/analyze-face-detection.js
+++ b/samples/analyze-face-detection.js
@@ -56,18 +56,6 @@ function main(path = 'YOUR_LOCAL_FILE') {
     for (const {tracks} of faceAnnotations) {
       console.log('Face detected:');
       for (const {segment, timestampedObjects} of tracks) {
-        if (segment.startTimeOffset.seconds === undefined) {
-          segment.startTimeOffset.seconds = 0;
-        }
-        if (segment.startTimeOffset.nanos === undefined) {
-          segment.startTimeOffset.nanos = 0;
-        }
-        if (segment.endTimeOffset.seconds === undefined) {
-          segment.endTimeOffset.seconds = 0;
-        }
-        if (segment.endTimeOffset.nanos === undefined) {
-          segment.endTimeOffset.nanos = 0;
-        }
         console.log(
           `\tStart: ${segment.startTimeOffset.seconds}` +
             `.${(segment.startTimeOffset.nanos / 1e6).toFixed(0)}s`

--- a/samples/analyze-person-detection-gcs.js
+++ b/samples/analyze-person-detection-gcs.js
@@ -54,18 +54,6 @@ function main(gcsUri = 'YOUR_STORAGE_URI') {
       console.log('Person detected:');
 
       for (const {segment, timestampedObjects} of tracks) {
-        if (segment.startTimeOffset.seconds === undefined) {
-          segment.startTimeOffset.seconds = 0;
-        }
-        if (segment.startTimeOffset.nanos === undefined) {
-          segment.startTimeOffset.nanos = 0;
-        }
-        if (segment.endTimeOffset.seconds === undefined) {
-          segment.endTimeOffset.seconds = 0;
-        }
-        if (segment.endTimeOffset.nanos === undefined) {
-          segment.endTimeOffset.nanos = 0;
-        }
         console.log(
           `\tStart: ${segment.startTimeOffset.seconds}` +
             `.${(segment.startTimeOffset.nanos / 1e6).toFixed(0)}s`

--- a/samples/analyze-person-detection.js
+++ b/samples/analyze-person-detection.js
@@ -63,18 +63,6 @@ function main(path = 'YOUR_LOCAL_FILE') {
       console.log('Person detected:');
 
       for (const {segment, timestampedObjects} of tracks) {
-        if (segment.startTimeOffset.seconds === undefined) {
-          segment.startTimeOffset.seconds = 0;
-        }
-        if (segment.startTimeOffset.nanos === undefined) {
-          segment.startTimeOffset.nanos = 0;
-        }
-        if (segment.endTimeOffset.seconds === undefined) {
-          segment.endTimeOffset.seconds = 0;
-        }
-        if (segment.endTimeOffset.nanos === undefined) {
-          segment.endTimeOffset.nanos = 0;
-        }
         console.log(
           `\tStart: ${segment.startTimeOffset.seconds}` +
             `.${(segment.startTimeOffset.nanos / 1e6).toFixed(0)}s`

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -48,18 +48,6 @@ async function main() {
     console.log(`Label ${label.entity.description} occurs at:`);
     label.segments.forEach(segment => {
       segment = segment.segment;
-      if (segment.startTimeOffset.seconds === undefined) {
-        segment.startTimeOffset.seconds = 0;
-      }
-      if (segment.startTimeOffset.nanos === undefined) {
-        segment.startTimeOffset.nanos = 0;
-      }
-      if (segment.endTimeOffset.seconds === undefined) {
-        segment.endTimeOffset.seconds = 0;
-      }
-      if (segment.endTimeOffset.nanos === undefined) {
-        segment.endTimeOffset.nanos = 0;
-      }
       console.log(
         `\tStart: ${segment.startTimeOffset.seconds}` +
           `.${(segment.startTimeOffset.nanos / 1e6).toFixed(0)}s`


### PR DESCRIPTION
Fixes b/149564760

This PR eliminates code blocks that set seconds to zero, if they are not provided by the response.  These are confirmed to be unnecessary for all the samples in the nodejs repo, and this approach is not needed in the python repo as well indicating that the response from the server is correct.
